### PR TITLE
fix reader hang for mulit-cards training

### DIFF
--- a/ppcls/data/reader.py
+++ b/ppcls/data/reader.py
@@ -140,7 +140,8 @@ def get_file_list(params):
     full_lines = shuffle_lines(full_lines, params["shuffle_seed"])
 
     # use only partial data for each trainer in distributed training
-    full_lines = full_lines[trainer_id::trainers_num]
+    img_per_trainer = len(full_lines) // trainers_num
+    full_lines = full_lines[trainer_id::trainers_num][:img_per_trainer]
 
     return full_lines
 


### PR DESCRIPTION
fix reader hang for mulit-cards training. Total minibatches' number must be equal for all trainer for normal exit.