### PR TITLE
Import paddleclas from  python package

### DIFF
--- a/ppcls/version.py
+++ b/ppcls/version.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2020  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" PaddleClas version string  """""
+__all__ = ["ppcls_version"]
+ppcls_version = "0.0.1"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,74 @@
+#   Copyright (c) 2020  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Setup for pip package."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import platform
+
+from setuptools import find_packages
+from setuptools import setup
+from ppcls.version import ppcls_version
+
+
+def read(*names, **kwargs):
+    with io.open(
+        os.path.join(os.path.dirname(__file__), *names),
+        encoding=kwargs.get("encoding", "utf8")
+    ) as fp:
+        return fp.read()
+readme = open('README.md').read()
+
+def python_version():
+    return [int(v) for v in platform.python_version().split(".")]
+
+
+max_version, mid_version, min_version = python_version()
+
+with open('./requirements.txt') as f:
+    setup_requires = f.read().splitlines()
+
+setup(
+    name='paddleclas',
+    version=ppcls_version,
+    description=('Image classification models for PaddlePaddle deep learning.'),
+    long_description=readme,
+    url='http://gitlab.baidu.com/PaddlePaddle/PaddleClas',
+    author='PaddleClas Core Team',
+    author_email='dltp-all@baidu.com',
+    install_requires=setup_requires,
+    packages=find_packages(exclude=('test',)),
+    # PyPI package information.
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    license='Apache 2.0',
+    keywords=('PaddleClas paddlepaddle image-classification'), 
+    zip_safe=False)


### PR DESCRIPTION
This PR
- recommend ```pip install paddleclas```(python setup.py install ) as the default way to start your engine instead of ```export PYTHONPATH="" ```