### PR TITLE
add support for file list delimiter

### DIFF
--- a/ppcls/data/reader.py
+++ b/ppcls/data/reader.py
@@ -188,7 +188,11 @@ def partial_reader(params, full_lines, part_id=0, part_num=1):
     def reader():
         ops = create_operators(params['transforms'])
         for line in full_lines:
-            img_path, label = line.split()
+            try:
+                delimiter = params['delimiter']
+            except KeyError:
+                delimiter = " "
+            img_path, label = line.split(delimiter)
             img_path = os.path.join(params['data_dir'], img_path)
             with open(img_path, 'rb') as f:
                 img = f.read()


### PR DESCRIPTION
sometimes filename in datasets may contain spaces, adding support for other delimiters avoid errors in this situation.
this change doesn't affect any code without the delimiter setting