### PR TITLE
add efficientnet-lite model

### DIFF
--- a/configs/EfficientNet/EfficientLite0.yaml
+++ b/configs/EfficientNet/EfficientLite0.yaml
@@ -1,11 +1,13 @@
 mode: 'train'
 ARCHITECTURE:
-    name: "EfficientNetB0"
+    name: "EfficientNetLite0"
     params:
         is_test: False
         padding_type : "SAME"
         override_params:
             drop_connect_rate: 0.1
+            fix_head_stem: True
+            relu_fn: True
 
 pretrained_model: ""
 model_save_dir: "./output/"
@@ -76,11 +78,11 @@ VALID:
             channel_first: False
         - ResizeImage:
             interpolation: 2
-            resize_short: 256
+            resize_short: 412
         - CropImage:
-            size: 224
+            size: 256
         - NormalizeImage:
-            scale: 1.0/255.0
+            scale: 1./255.
             mean: [0.485, 0.456, 0.406]
             std: [0.229, 0.224, 0.225]
             order: ''

--- a/configs/EfficientNet/EfficientLite0.yaml
+++ b/configs/EfficientNet/EfficientLite0.yaml
@@ -78,9 +78,9 @@ VALID:
             channel_first: False
         - ResizeImage:
             interpolation: 2
-            resize_short: 412
+            resize_short: 256
         - CropImage:
-            size: 256
+            size: 224
         - NormalizeImage:
             scale: 1./255.
             mean: [0.485, 0.456, 0.406]

--- a/configs/EfficientNet/EfficientLite0.yaml
+++ b/configs/EfficientNet/EfficientLite0.yaml
@@ -52,7 +52,7 @@ TRAIN:
             channel_first: False
         - RandCropImage:
             size: 224
-            interpolation: 2
+            interpolation: 1
         - RandFlipImage:
             flip_code: 1
         - AutoAugment:
@@ -77,7 +77,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            interpolation: 2
+            interpolation: 1
             resize_short: 256
         - CropImage:
             size: 224

--- a/ppcls/modeling/architectures/__init__.py
+++ b/ppcls/modeling/architectures/__init__.py
@@ -37,6 +37,9 @@ from .squeezenet import SqueezeNet1_0, SqueezeNet1_1
 from .darknet import DarkNet53
 from .resnext101_wsl import ResNeXt101_32x8d_wsl, ResNeXt101_32x16d_wsl, ResNeXt101_32x32d_wsl, ResNeXt101_32x48d_wsl, Fix_ResNeXt101_32x48d_wsl
 from .efficientnet import EfficientNet, EfficientNetB0, EfficientNetB0_small, EfficientNetB1, EfficientNetB2, EfficientNetB3, EfficientNetB4, EfficientNetB5, EfficientNetB6, EfficientNetB7
+
+from .efficientnetlite import EfficientNetLite, EfficientNetLite0, EfficientNetLite1, EfficientNetLite2, EfficientNetLite4
+
 from .res2net import Res2Net50_48w_2s, Res2Net50_26w_4s, Res2Net50_14w_8s, Res2Net50_26w_6s, Res2Net50_26w_8s, Res2Net101_26w_4s, Res2Net152_26w_4s
 from .res2net_vd import Res2Net50_vd_48w_2s, Res2Net50_vd_26w_4s, Res2Net50_vd_14w_8s, Res2Net50_vd_26w_6s, Res2Net50_vd_26w_8s, Res2Net101_vd_26w_4s, Res2Net152_vd_26w_4s, Res2Net200_vd_26w_4s
 from .hrnet import HRNet_W18_C, HRNet_W30_C, HRNet_W32_C, HRNet_W40_C, HRNet_W44_C, HRNet_W48_C, HRNet_W60_C, HRNet_W64_C, SE_HRNet_W18_C, SE_HRNet_W30_C, SE_HRNet_W32_C, SE_HRNet_W40_C, SE_HRNet_W44_C, SE_HRNet_W48_C, SE_HRNet_W60_C, SE_HRNet_W64_C

--- a/ppcls/modeling/architectures/layers.py
+++ b/ppcls/modeling/architectures/layers.py
@@ -1,16 +1,16 @@
-#copyright (c) 2020 PaddlePaddle Authors. All Rights Reserve.
+# copyright (c) 2020 PaddlePaddle Authors. All Rights Reserve.
 #
-#Licensed under the Apache License, Version 2.0 (the "License");
-#you may not use this file except in compliance with the License.
-#You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 #    http://www.apache.org/licenses/LICENSE-2.0
 #
-#Unless required by applicable law or agreed to in writing, software
-#distributed under the License is distributed on an "AS IS" BASIS,
-#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#See the License for the specific language governing permissions and
-#limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import absolute_import
 from __future__ import division
@@ -242,6 +242,8 @@ def conv2d(input,
         conv = fluid.layers.sigmoid(conv, name=name + '_sigmoid')
     elif act == 'swish':
         conv = fluid.layers.swish(conv, name=name + '_swish')
+    elif act == 'relu6':
+        conv = fluid.layers.relu6(conv, name=name + '_relu6')
     elif act == None:
         conv = conv
     else:


### PR DESCRIPTION
This PR
- add efficientnet-lite model

There are some changes between EfficientNet and EfficientNet-Lite model, 

one purpose is trying to suit the edge device,
- delete se
- local_pooling
- fix head and stem (reduce params)

the other is better for post-quantization.
- swish -> relu6
- bilinear intepolation
- inception preprocessing

performance: