### PR TITLE
fix dist strategy

### DIFF
--- a/configs/EfficientNet/EfficientLite0.yaml
+++ b/configs/EfficientNet/EfficientLite0.yaml
@@ -8,6 +8,8 @@ ARCHITECTURE:
             drop_connect_rate: 0.1
             fix_head_stem: True
             relu_fn: True
+            local_pooling: True
+        use_se: False
 
 pretrained_model: ""
 model_save_dir: "./output/"

--- a/tools/program.py
+++ b/tools/program.py
@@ -297,6 +297,8 @@ def dist_optimizer(config, optimizer):
     dist_strategy.nccl_comm_num = 1
     dist_strategy.fuse_all_reduce_ops = True
     dist_strategy.exec_strategy = exec_strategy
+    dist_strategy.mode = "collective"
+    dist_strategy.collective_mode = "grad_allreduce"
     optimizer = fleet.distributed_optimizer(optimizer, strategy=dist_strategy)
 
     return optimizer


### PR DESCRIPTION
This PR
- fix distribute strategy when using Fleet interface.
when some operations, such as EMA, are applied after calling 'minimize' function,  They won't insert in the graph, because the graph is already restored in fleet.main_program.
To solve this problem, switch collective mode on now 