### PR TITLE
fix log benchmark

### DIFF
--- a/ppcls/utils/misc.py
+++ b/ppcls/utils/misc.py
@@ -20,9 +20,10 @@ class AverageMeter(object):
     Computes and stores the average and current value
     """
 
-    def __init__(self, name='', fmt='f', need_avg=True):
+    def __init__(self, name='', fmt='f', postfix="", need_avg=True):
         self.name = name
         self.fmt = fmt
+        self.postfix = postfix
         self.need_avg = need_avg
         self.reset()
 
@@ -42,18 +43,20 @@ class AverageMeter(object):
 
     @property
     def total(self):
-        return '{self.name}_sum: {self.sum:{self.fmt}}'.format(self=self)
+        return '{self.name}_sum: {self.sum:{self.fmt}}{self.postfix}'.format(
+            self=self)
 
     @property
     def total_minute(self):
-        return '{self.name}_sum: {s:{self.fmt}} min'.format(
+        return '{self.name}_sum: {s:{self.fmt}}{self.postfix} min'.format(
             s=self.sum / 60, self=self)
 
     @property
     def mean(self):
-        return '{self.name}_avg: {self.avg:{self.fmt}}'.format(
+        return '{self.name}_avg: {self.avg:{self.fmt}}{self.postfix}'.format(
             self=self) if self.need_avg else ''
 
     @property
     def value(self):
-        return '{self.name}: {self.val:{self.fmt}}'.format(self=self)
+        return '{self.name}: {self.val:{self.fmt}}{self.postfix}'.format(
+            self=self)

--- a/tools/program.py
+++ b/tools/program.py
@@ -36,24 +36,6 @@ from ppcls.utils.misc import AverageMeter
 from ppcls.utils import logger
 
 
-def create_dataloader():
-    """
-    Create a dataloader with model input variables
-
-    Args:
-        feeds(dict): dict of model input variables
-
-    Returns:
-        dataloader(paddle dataloader):
-    """
-    trainer_num = int(os.environ.get('PADDLE_TRAINERS_NUM', 1))
-    capacity = 64 if trainer_num == 1 else 8
-    dataloader = paddle.io.DataLoader.from_generator(
-        capacity=capacity, use_double_buffer=True, iterable=True)
-
-    return dataloader
-
-
 def create_model(architecture, classes_num):
     """
     Create a model

--- a/tools/program.py
+++ b/tools/program.py
@@ -329,10 +329,8 @@ def run(dataloader,
         fetchs_str = ' '.join([str(m.value) for m in metric_list.values()])
 
         if idx % print_interval == 0:
-            total_batch_size = batch_size * config.get(
-                "trainer_num", 1) if mode == "train" else batch_size
             ips_info = "ips: {:.5f} images/sec.".format(
-                total_batch_size / metric_list["batch_time"].val)
+                batch_size / metric_list["batch_time"].val)
             if mode == 'eval':
                 logger.info("{:s} step:{:<4d}, {:s} {:s}".format(
                     mode, idx, fetchs_str, ips_info))
@@ -348,10 +346,8 @@ def run(dataloader,
 
     end_str = ' '.join([str(m.mean) for m in metric_list.values()] +
                        [metric_list['batch_time'].total])
-    total_batch_size = batch_size * config.get(
-        "trainer_num", 1) if mode == "train" else batch_size
     ips_info = "ips: {:.5f} images/sec.".format(
-        total_batch_size * metric_list["batch_time"].count /
+        batch_size * metric_list["batch_time"].count /
         metric_list["batch_time"].sum)
 
     if mode == 'eval':

--- a/tools/train.py
+++ b/tools/train.py
@@ -63,7 +63,6 @@ def main(args):
     trainer_num = int(os.getenv("PADDLE_TRAINERS_NUM", 1))
     use_data_parallel = trainer_num != 1
     config["use_data_parallel"] = use_data_parallel
-    config["trainer_num"] = trainer_num
 
     if config["use_data_parallel"]:
         strategy = paddle.distributed.init_parallel_env()

--- a/tools/train.py
+++ b/tools/train.py
@@ -60,8 +60,10 @@ def main(args):
     place = 'gpu:{}'.format(ParallelEnv().dev_id) if use_gpu else 'cpu'
     place = paddle.set_device(place)
 
-    use_data_parallel = int(os.getenv("PADDLE_TRAINERS_NUM", 1)) != 1
+    trainer_num = int(os.getenv("PADDLE_TRAINERS_NUM", 1))
+    use_data_parallel = trainer_num != 1
     config["use_data_parallel"] = use_data_parallel
+    config["trainer_num"] = trainer_num
 
     if config["use_data_parallel"]:
         strategy = paddle.distributed.init_parallel_env()


### PR DESCRIPTION
as title, add units, and ips info.
1. for log without mix

* before
```
2020-10-11 12:12:00 INFO: epoch:0   train step:310  loss: 6.88331 top1: 0.00000 top5: 0.03125 lr: 0.100000 elapse: 0.1418407 reader : 0.0020440s
```

* now
```
2020-11-04 17:25:52 INFO: epoch:0  , train step:50  , loss: 6.92608, top1: 0.00000, top5: 0.00000, lr: 0.100000, batch_cost: 0.28419 s, reader_cost: 0.00056 s, ips: 225.20036 images/sec.
```

2. for log with mix

* before
```
2020-10-12 19:34:19 INFO: epoch:0   train step:2280 loss: 6.06281 lr: 0.099999 elapse: 0.1568401 reader : 0.0018728s
```

* now
```
2020-11-04 17:27:28 INFO: epoch:0  , train step:30  , loss: 7.07572, lr: 0.100000, batch_cost: 0.25251 s, reader_cost: 0.00040 s, ips: 253.45093 images/sec.
```