### PR TITLE
Add RepVGG models

### DIFF
--- a/configs/RepVGG/RepVGG_A0.yaml
+++ b/configs/RepVGG/RepVGG_A0.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_A0'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_A1.yaml
+++ b/configs/RepVGG/RepVGG_A1.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_A1'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_A2.yaml
+++ b/configs/RepVGG/RepVGG_A2.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_A2'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B0.yaml
+++ b/configs/RepVGG/RepVGG_B0.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B0'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B1.yaml
+++ b/configs/RepVGG/RepVGG_B1.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B1'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B1g2.yaml
+++ b/configs/RepVGG/RepVGG_B1g2.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B1g2'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B1g4.yaml
+++ b/configs/RepVGG/RepVGG_B1g4.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B1g4'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B2.yaml
+++ b/configs/RepVGG/RepVGG_B2.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B2'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B2g2.yaml
+++ b/configs/RepVGG/RepVGG_B2g2.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B2g2'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B2g4.yaml
+++ b/configs/RepVGG/RepVGG_B2g4.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B2g4'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B3.yaml
+++ b/configs/RepVGG/RepVGG_B3.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B3'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B3g2.yaml
+++ b/configs/RepVGG/RepVGG_B3g2.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B3g2'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/configs/RepVGG/RepVGG_B3g4.yaml
+++ b/configs/RepVGG/RepVGG_B3g4.yaml
@@ -1,0 +1,74 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'RepVGG_B3g4'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [3, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+LEARNING_RATE:
+    function: 'Cosine'          
+    params:                   
+        lr: 0.001             
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:

--- a/docs/en/models/RepVGG_en.md
+++ b/docs/en/models/RepVGG_en.md
@@ -1,0 +1,27 @@
+# RepVGG series
+
+## Overview
+
+RepVGG (Making VGG-style ConvNets Great Again) series model is a simple but powerful convolutional neural network architecture proposed by Tsinghua University (Guiguang Ding's team), MEGVII Technology (Jian Sun et al.), HKUST and Aberystwyth University in 2021. The architecture has an inference time agent similar to VGG. The main body is composed of 3x3 convolution and relu stack, while the training time model has multi branch topology. The decoupling of training time and inference time is realized by re-parameterization technology, so the model is called repvgg.
+
+## Accuracy, FLOPS and Parameters
+
+| Models | Top1 | Top5 | Reference<br>top1| FLOPS<br>(G) |
+|:--:|:--:|:--:|:--:|:--:|
+| RepVGG_A0 | 0.7131 | 0.9016 | 0.7241 |     |
+| RepVGG_A1 | 0.7380 | 0.9146 | 0.7446 |     |
+| RepVGG_A2 | 0.7571 | 0.9264 | 0.7648 |     |
+| RepVGG_B0 | 0.7450 | 0.9213 | 0.7514 |     |
+| RepVGG_B1 | 0.7773 | 0.9385 | 0.7837 |     |
+| RepVGG_B2 | 0.7813 | 0.9410 | 0.7878 |     |
+| RepVGG_B1g2 | 0.7732 | 0.9359 | 0.7778 |    |
+| RepVGG_B1g4 | 0.7675 | 0.9335 | 0.7758 |    |
+| RepVGG_B2g4 | 0.7782 | 0.9380 | 0.7850 |    |
+
+| Models | Top1 | Top5 | Reference<br>top1 | FLOPS<br>(G) |
+|:--:|:--:|:--:|:--:|:--:|
+| RepVGG_B3_200epochs | 0.7987 | 0.9502 | 0.8052 |      |
+| RepVGG_B2g4_200epochs | 0.7881 | 0.9448 | 0.7938 |     |
+| RepVGG_B3g4_200epochs | 0.7965 | 0.9485 | 0.8021 |     |
+
+Params, FLOPs, Inference speed and other information are coming soon.

--- a/docs/en/models/RepVGG_en.md
+++ b/docs/en/models/RepVGG_en.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-RepVGG (Making VGG-style ConvNets Great Again) series model is a simple but powerful convolutional neural network architecture proposed by Tsinghua University (Guiguang Ding's team), MEGVII Technology (Jian Sun et al.), HKUST and Aberystwyth University in 2021. The architecture has an inference time agent similar to VGG. The main body is composed of 3x3 convolution and relu stack, while the training time model has multi branch topology. The decoupling of training time and inference time is realized by re-parameterization technology, so the model is called repvgg.
+RepVGG (Making VGG-style ConvNets Great Again) series model is a simple but powerful convolutional neural network architecture proposed by Tsinghua University (Guiguang Ding's team), MEGVII Technology (Jian Sun et al.), HKUST and Aberystwyth University in 2021. The architecture has an inference time agent similar to VGG. The main body is composed of 3x3 convolution and relu stack, while the training time model has multi branch topology. The decoupling of training time and inference time is realized by re-parameterization technology, so the model is called repvgg. [paper](https://arxiv.org/abs/2101.03697).
 
 ## Accuracy, FLOPS and Parameters
 

--- a/docs/zh_CN/models/RepVGG.md
+++ b/docs/zh_CN/models/RepVGG.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-RepVGG（Making VGG-style ConvNets Great Again）系列模型是有清华大学(丁贵广团队)、旷视科技(孙剑等人)、港科大和阿伯里斯特威斯大学在2021年提出的一个简单但强大的卷积神经网络架构，该架构具有类似于VGG的推理时间主体，该主体仅由3x3卷积和ReLU的堆栈组成，而训练时间模型具有多分支拓扑。训练时间和推理时间架构的这种解耦是通过结构重新参数化(re-parameterization)技术实现的，因此该模型称为RepVGG。[论文地址](https://arxiv.org/abs/2101.03697)。
+RepVGG（Making VGG-style ConvNets Great Again）系列模型是由清华大学(丁贵广团队)、旷视科技(孙剑等人)、港科大和阿伯里斯特威斯大学在2021年提出的一个简单但强大的卷积神经网络架构，该架构具有类似于VGG的推理时间主体，该主体仅由3x3卷积和ReLU的堆栈组成，而训练时间模型具有多分支拓扑。训练时间和推理时间架构的这种解耦是通过结构重新参数化(re-parameterization)技术实现的，因此该模型称为RepVGG。[论文地址](https://arxiv.org/abs/2101.03697)。
 
 
 ## 精度、FLOPS和参数量

--- a/docs/zh_CN/models/RepVGG.md
+++ b/docs/zh_CN/models/RepVGG.md
@@ -1,0 +1,28 @@
+# RepVGG系列
+
+## 概述
+
+RepVGG（Making VGG-style ConvNets Great Again）系列模型是有清华大学(丁贵广团队)、旷视科技(孙剑等人)、港科大和阿伯里斯特威斯大学在2021年提出的一个简单但强大的卷积神经网络架构，该架构具有类似于VGG的推理时间主体，该主体仅由3x3卷积和ReLU的堆栈组成，而训练时间模型具有多分支拓扑。训练时间和推理时间架构的这种解耦是通过结构重新参数化(re-parameterization)技术实现的，因此该模型称为RepVGG。[论文地址](https://arxiv.org/abs/2101.03697)。
+
+
+## 精度、FLOPS和参数量
+
+| Models | Top1 | Top5 | Reference<br>top1| FLOPS<br>(G) |
+|:--:|:--:|:--:|:--:|:--:|
+| RepVGG_A0 | 0.7131 | 0.9016 | 0.7241 |     |
+| RepVGG_A1 | 0.7380 | 0.9146 | 0.7446 |     |
+| RepVGG_A2 | 0.7571 | 0.9264 | 0.7648 |     |
+| RepVGG_B0 | 0.7450 | 0.9213 | 0.7514 |     |
+| RepVGG_B1 | 0.7773 | 0.9385 | 0.7837 |     |
+| RepVGG_B2 | 0.7813 | 0.9410 | 0.7878 |     |
+| RepVGG_B1g2 | 0.7732 | 0.9359 | 0.7778 |    |
+| RepVGG_B1g4 | 0.7675 | 0.9335 | 0.7758 |    |
+| RepVGG_B2g4 | 0.7782 | 0.9380 | 0.7850 |    |
+
+| Models | Top1 | Top5 | Reference<br>top1 | FLOPS<br>(G) |
+|:--:|:--:|:--:|:--:|:--:|
+| RepVGG_B3_200epochs | 0.7987 | 0.9502 | 0.8052 |      |
+| RepVGG_B2g4_200epochs | 0.7881 | 0.9448 | 0.7938 |     |
+| RepVGG_B3g4_200epochs | 0.7965 | 0.9485 | 0.8021 |     |
+
+关于Params、FLOPs、Inference speed等信息，敬请期待。

--- a/ppcls/modeling/architectures/__init__.py
+++ b/ppcls/modeling/architectures/__init__.py
@@ -46,3 +46,5 @@ from .regnet import RegNetX_200MF, RegNetX_4GF, RegNetX_32GF, RegNetY_200MF, Reg
 from .vision_transformer import ViT_small_patch16_224, ViT_base_patch16_224, ViT_base_patch16_384, ViT_base_patch32_384, ViT_large_patch16_224, ViT_large_patch16_384, ViT_large_patch32_384, ViT_huge_patch16_224, ViT_huge_patch32_384
 from .distilled_vision_transformer import DeiT_tiny_patch16_224, DeiT_small_patch16_224, DeiT_base_patch16_224, DeiT_tiny_distilled_patch16_224, DeiT_small_distilled_patch16_224, DeiT_base_distilled_patch16_224, DeiT_base_patch16_384, DeiT_base_distilled_patch16_384
 from .distillation_models import ResNet50_vd_distill_MobileNetV3_large_x1_0
+from .repvgg import RepVGG_A0, RepVGG_A1, RepVGG_A2, RepVGG_B0, RepVGG_B1, RepVGG_B2, RepVGG_B3, RepVGG_B1g2, RepVGG_B1g4, RepVGG_B2g2, RepVGG_B2g4, RepVGG_B3g2, RepVGG_B3g4
+

--- a/ppcls/modeling/architectures/repvgg.py
+++ b/ppcls/modeling/architectures/repvgg.py
@@ -1,0 +1,230 @@
+import paddle.nn as nn
+import paddle
+import numpy as np
+
+__all__ = [
+    'RepVGG',
+    'RepVGG_A0', 'RepVGG_A1', 'RepVGG_A2',
+    'RepVGG_B0', 'RepVGG_B1', 'RepVGG_B2', 'RepVGG_B3',
+    'RepVGG_B1g2', 'RepVGG_B1g4',
+    'RepVGG_B2g2', 'RepVGG_B2g4',
+    'RepVGG_B3g2', 'RepVGG_B3g4',
+]
+
+
+def conv_bn(in_channels, out_channels, kernel_size, stride, padding, groups=1):
+    result = nn.Sequential()
+    result.add_sublayer('conv', nn.Conv2D(in_channels=in_channels, out_channels=out_channels,
+                                          kernel_size=kernel_size, stride=stride, padding=padding, groups=groups, bias_attr=False))
+    result.add_sublayer('bn', nn.BatchNorm2D(num_features=out_channels))
+    return result
+
+
+class RepVGGBlock(nn.Layer):
+
+    def __init__(self, in_channels, out_channels, kernel_size,
+                 stride=1, padding=0, dilation=1, groups=1, padding_mode='zeros'):
+        super(RepVGGBlock, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+        self.padding_mode = padding_mode
+
+        assert kernel_size == 3
+        assert padding == 1
+
+        padding_11 = padding - kernel_size // 2
+
+        self.nonlinearity = nn.ReLU()
+
+        self.rbr_identity = nn.BatchNorm2D(
+            num_features=in_channels) if out_channels == in_channels and stride == 1 else None
+        self.rbr_dense = conv_bn(in_channels=in_channels, out_channels=out_channels,
+                                 kernel_size=kernel_size, stride=stride, padding=padding, groups=groups)
+        self.rbr_1x1 = conv_bn(in_channels=in_channels, out_channels=out_channels,
+                               kernel_size=1, stride=stride, padding=padding_11, groups=groups)
+
+    def forward(self, inputs):
+        if not self.training:
+            return self.nonlinearity(self.rbr_reparam(inputs))
+
+        if self.rbr_identity is None:
+            id_out = 0
+        else:
+            id_out = self.rbr_identity(inputs)
+        return self.nonlinearity(self.rbr_dense(inputs) + self.rbr_1x1(inputs) + id_out)
+
+    def eval(self):
+        if not hasattr(self, 'rbr_reparam'):
+            self.rbr_reparam = nn.Conv2D(in_channels=self.in_channels, out_channels=self.out_channels, kernel_size=self.kernel_size, stride=self.stride,
+                                         padding=self.padding, dilation=self.dilation, groups=self.groups, padding_mode=self.padding_mode)
+        self.training = False
+        kernel, bias = self.get_equivalent_kernel_bias()
+        self.rbr_reparam.weight.set_value(kernel)
+        self.rbr_reparam.bias.set_value(bias)
+        for layer in self.sublayers():
+            layer.eval()
+
+    def get_equivalent_kernel_bias(self):
+        kernel3x3, bias3x3 = self._fuse_bn_tensor(self.rbr_dense)
+        kernel1x1, bias1x1 = self._fuse_bn_tensor(self.rbr_1x1)
+        kernelid, biasid = self._fuse_bn_tensor(self.rbr_identity)
+        return kernel3x3 + self._pad_1x1_to_3x3_tensor(kernel1x1) + kernelid, bias3x3 + bias1x1 + biasid
+
+    def _pad_1x1_to_3x3_tensor(self, kernel1x1):
+        if kernel1x1 is None:
+            return 0
+        else:
+            return nn.functional.pad(kernel1x1, [1, 1, 1, 1])
+
+    def _fuse_bn_tensor(self, branch):
+        if branch is None:
+            return 0, 0
+        if isinstance(branch, nn.Sequential):
+            kernel = branch.conv.weight
+            running_mean = branch.bn._mean
+            running_var = branch.bn._variance
+            gamma = branch.bn.weight
+            beta = branch.bn.bias
+            eps = branch.bn._epsilon
+        else:
+            assert isinstance(branch, nn.BatchNorm2D)
+            if not hasattr(self, 'id_tensor'):
+                input_dim = self.in_channels // self.groups
+                kernel_value = np.zeros(
+                    (self.in_channels, input_dim, 3, 3), dtype=np.float32)
+                for i in range(self.in_channels):
+                    kernel_value[i, i % input_dim, 1, 1] = 1
+                self.id_tensor = paddle.to_tensor(kernel_value)
+            kernel = self.id_tensor
+            running_mean = branch._mean
+            running_var = branch._variance
+            gamma = branch.weight
+            beta = branch.bias
+            eps = branch._epsilon
+        std = (running_var + eps).sqrt()
+        t = (gamma / std).reshape((-1, 1, 1, 1))
+        return kernel * t, beta - running_mean * gamma / std
+
+
+class RepVGG(nn.Layer):
+
+    def __init__(self, num_blocks, width_multiplier=None, override_groups_map=None, class_dim=1000):
+        super(RepVGG, self).__init__()
+
+        assert len(width_multiplier) == 4
+        self.override_groups_map = override_groups_map or dict()
+
+        assert 0 not in self.override_groups_map
+
+        self.in_planes = min(64, int(64 * width_multiplier[0]))
+
+        self.stage0 = RepVGGBlock(
+            in_channels=3, out_channels=self.in_planes, kernel_size=3, stride=2, padding=1)
+        self.cur_layer_idx = 1
+        self.stage1 = self._make_stage(
+            int(64 * width_multiplier[0]), num_blocks[0], stride=2)
+        self.stage2 = self._make_stage(
+            int(128 * width_multiplier[1]), num_blocks[1], stride=2)
+        self.stage3 = self._make_stage(
+            int(256 * width_multiplier[2]), num_blocks[2], stride=2)
+        self.stage4 = self._make_stage(
+            int(512 * width_multiplier[3]), num_blocks[3], stride=2)
+        self.gap = nn.AdaptiveAvgPool2D(output_size=1)
+        self.linear = nn.Linear(int(512 * width_multiplier[3]), class_dim)
+
+    def _make_stage(self, planes, num_blocks, stride):
+        strides = [stride] + [1]*(num_blocks-1)
+        blocks = []
+        for stride in strides:
+            cur_groups = self.override_groups_map.get(self.cur_layer_idx, 1)
+            blocks.append(RepVGGBlock(in_channels=self.in_planes, out_channels=planes, kernel_size=3,
+                                      stride=stride, padding=1, groups=cur_groups))
+            self.in_planes = planes
+            self.cur_layer_idx += 1
+        return nn.Sequential(*blocks)
+
+    def forward(self, x):
+        out = self.stage0(x)
+        out = self.stage1(out)
+        out = self.stage2(out)
+        out = self.stage3(out)
+        out = self.stage4(out)
+        out = self.gap(out)
+        out = paddle.flatten(out, start_axis=1)
+        out = self.linear(out)
+        return out
+
+
+optional_groupwise_layers = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26]
+g2_map = {l: 2 for l in optional_groupwise_layers}
+g4_map = {l: 4 for l in optional_groupwise_layers}
+
+
+def RepVGG_A0(**kwargs):
+    return RepVGG(num_blocks=[2, 4, 14, 1],
+                  width_multiplier=[0.75, 0.75, 0.75, 2.5], override_groups_map=None, **kwargs)
+
+
+def RepVGG_A1(**kwargs):
+    return RepVGG(num_blocks=[2, 4, 14, 1],
+                  width_multiplier=[1, 1, 1, 2.5], override_groups_map=None, **kwargs)
+
+
+def RepVGG_A2(**kwargs):
+    return RepVGG(num_blocks=[2, 4, 14, 1],
+                  width_multiplier=[1.5, 1.5, 1.5, 2.75], override_groups_map=None, **kwargs)
+
+
+def RepVGG_B0(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[1, 1, 1, 2.5], override_groups_map=None, **kwargs)
+
+
+def RepVGG_B1(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[2, 2, 2, 4], override_groups_map=None, **kwargs)
+
+
+def RepVGG_B1g2(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[2, 2, 2, 4], override_groups_map=g2_map, **kwargs)
+
+
+def RepVGG_B1g4(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[2, 2, 2, 4], override_groups_map=g4_map, **kwargs)
+
+
+def RepVGG_B2(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[2.5, 2.5, 2.5, 5], override_groups_map=None, **kwargs)
+
+
+def RepVGG_B2g2(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[2.5, 2.5, 2.5, 5], override_groups_map=g2_map, **kwargs)
+
+
+def RepVGG_B2g4(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[2.5, 2.5, 2.5, 5], override_groups_map=g4_map, **kwargs)
+
+
+def RepVGG_B3(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[3, 3, 3, 5], override_groups_map=None, **kwargs)
+
+
+def RepVGG_B3g2(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[3, 3, 3, 5], override_groups_map=g2_map, **kwargs)
+
+
+def RepVGG_B3g4(**kwargs):
+    return RepVGG(num_blocks=[4, 6, 16, 1],
+                  width_multiplier=[3, 3, 3, 5], override_groups_map=g4_map, **kwargs)

--- a/ppcls/modeling/architectures/repvgg.py
+++ b/ppcls/modeling/architectures/repvgg.py
@@ -49,9 +49,9 @@ class RepVGGBlock(nn.Layer):
         self.rbr_identity = nn.BatchNorm2D(
             num_features=in_channels) if out_channels == in_channels and stride == 1 else None
         self.rbr_dense = ConvBN(in_channels=in_channels, out_channels=out_channels,
-                                 kernel_size=kernel_size, stride=stride, padding=padding, groups=groups)
+                                kernel_size=kernel_size, stride=stride, padding=padding, groups=groups)
         self.rbr_1x1 = ConvBN(in_channels=in_channels, out_channels=out_channels,
-                               kernel_size=1, stride=stride, padding=padding_11, groups=groups)
+                              kernel_size=1, stride=stride, padding=padding_11, groups=groups)
 
     def forward(self, inputs):
         if not self.training:

--- a/ppcls/modeling/architectures/repvgg.py
+++ b/ppcls/modeling/architectures/repvgg.py
@@ -12,9 +12,9 @@ __all__ = [
 ]
 
 
-class Conv_BN(nn.Layer):
+class ConvBN(nn.Layer):
     def __init__(self, in_channels, out_channels, kernel_size, stride, padding, groups=1):
-        super(Conv_BN, self).__init__()
+        super(ConvBN, self).__init__()
         self.conv = nn.Conv2D(in_channels=in_channels, out_channels=out_channels,
                               kernel_size=kernel_size, stride=stride, padding=padding, groups=groups, bias_attr=False)
         self.bn = nn.BatchNorm2D(num_features=out_channels)
@@ -48,9 +48,9 @@ class RepVGGBlock(nn.Layer):
 
         self.rbr_identity = nn.BatchNorm2D(
             num_features=in_channels) if out_channels == in_channels and stride == 1 else None
-        self.rbr_dense = Conv_BN(in_channels=in_channels, out_channels=out_channels,
+        self.rbr_dense = ConvBN(in_channels=in_channels, out_channels=out_channels,
                                  kernel_size=kernel_size, stride=stride, padding=padding, groups=groups)
-        self.rbr_1x1 = Conv_BN(in_channels=in_channels, out_channels=out_channels,
+        self.rbr_1x1 = ConvBN(in_channels=in_channels, out_channels=out_channels,
                                kernel_size=1, stride=stride, padding=padding_11, groups=groups)
 
     def forward(self, inputs):
@@ -89,7 +89,7 @@ class RepVGGBlock(nn.Layer):
     def _fuse_bn_tensor(self, branch):
         if branch is None:
             return 0, 0
-        if isinstance(branch, Conv_BN):
+        if isinstance(branch, ConvBN):
             kernel = branch.conv.weight
             running_mean = branch.bn._mean
             running_var = branch.bn._variance


### PR DESCRIPTION
添加 RepVGG 模型，参考官方开源项目  [【DingXiaoH/RepVGG】](https://github.com/DingXiaoH/RepVGG) 开发
预训练模型转换至官方开源项目 [【DingXiaoH/RepVGG】](https://github.com/DingXiaoH/RepVGG)：[下载链接 part1](https://aistudio.baidu.com/aistudio/datasetdetail/69662)、[下载链接 part2](https://aistudio.baidu.com/aistudio/datasetdetail/69680)
精度方面：如果使用自定义数据集，ImageNet 验证精度与官方项目标称基本上是完全一样的，具体代码如下：
```python
import paddle
import numpy as np
from PIL import Image
import paddle.vision.transforms as transforms
class DataSet(paddle.io.Dataset):
    def __init__(self, root, label_list, transform):
        self.transform = transform
        self.root = root
        self.label_list = label_list
        self.load_datas()

    def load_datas(self):
        self.imgs = []
        self.labels = []
        with open(self.label_list, 'r') as f:
            for line in f:
                img, label = line[:-1].split(' ')
                self.imgs.append(os.path.join(self.root, img))
                self.labels.append(int(label))

    def __getitem__(self, idx):
        label = self.labels[idx]
        image = self.imgs[idx]

        image = Image.open(image).convert('RGB')
        image = self.transform(image)


        return image.astype('float32'), np.array(label).astype('int64')

    def __len__(self):
        return len(self.imgs)

normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                    std=[0.229, 0.224, 0.225])

val_loader = paddle.io.DataLoader(
    DataSet('../ILSVRC2012', transform=transforms.Compose([
        transforms.Resize(256),
        transforms.CenterCrop(224),
        transforms.ToTensor(),
        normalize,
    ]), label_list='../ILSVRC2012/val_list.txt'),
    batch_size=64, shuffle=False,
    num_workers=0)
```
但如果使用 PaddleClas 的配置文件，将其配置为相同配置，则精度会有1%左右的降低，具体配置如下：
```python
VALID:
    batch_size: 64
    num_workers: 0
    file_list: "../ILSVRC2012/val_list.txt"
    data_dir: "../ILSVRC2012/"
    shuffle_seed: 0
    transforms:
        - DecodeImage:
            to_rgb: True
            to_np: False
            channel_first: False
        - ResizeImage:
            resize_short: 256
        - CropImage:
            size: 224
        - NormalizeImage:
            scale: 1.0/255.0
            mean: [0.485, 0.456, 0.406]
            std: [0.229, 0.224, 0.225]
            order: ''
        - ToCHWImage:
```
之前的 ViT 和 DeiT 模型的精度下降也可能是这个原因
经过代码对比，感觉应该是 opencv 和 PIL 处理的差异
这里不知道要怎么处理比较好一些