### PR TITLE
Update the Configs of  ViT and DeiT models 

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,14 +373,14 @@ Accuracy and inference time metrics of ViT and DeiT series models are shown as f
 
 | Model                    | Top-1 Acc | Top-5 Acc | time(ms)<br>bs=1 | time(ms)<br>bs=4 | Flops(G) | Params(M) | Download Address |
 |------------------------|-----------|-----------|------------------|------------------|----------|------------------------|------------------------|
-| DeiT_tiny_<br>patch16_224 | 0.709 | 0.906 | -                | -                |      | 5 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_patch16_224_pretrained.pdparams) |
-| DeiT_small_<br>patch16_224 | 0.794 | 0.948 | -    | -                |     | 22 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>patch16_224 | 0.816 | 0.955 |    -              |      -           |         | 86 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>patch16_384 | 0.831 | 0.962 | - | - |  | 87 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_384_pretrained.pdparams) |
-| DeiT_tiny_<br>distilled_patch16_224 | 0.736 | 0.915 | - | - |  | 6 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_distilled_patch16_224_pretrained.pdparams) |
-| DeiT_small_<br>distilled_patch16_224 | 0.810 | 0.953 | - | - |  | 22 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_distilled_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>distilled_patch16_224 | 0.830 | 0.963 | - | - |  | 87 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>distilled_patch16_384 | 0.855 | 0.974 | - | - |  | 88 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_384_pretrained.pdparams) |
+| DeiT_tiny_<br>patch16_224 | 0.718 | 0.910 | -                | -                |      | 5 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_patch16_224_pretrained.pdparams) |
+| DeiT_small_<br>patch16_224 | 0.796 | 0.949 | -    | -                |     | 22 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>patch16_224 | 0.817 | 0.957 |    -              |      -           |         | 86 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>patch16_384 | 0.830 | 0.962 | - | - |  | 87 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_384_pretrained.pdparams) |
+| DeiT_tiny_<br>distilled_patch16_224 | 0.741 | 0.918 | - | - |  | 6 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_distilled_patch16_224_pretrained.pdparams) |
+| DeiT_small_<br>distilled_patch16_224 | 0.809 | 0.953 | - | - |  | 22 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_distilled_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>distilled_patch16_224 | 0.831 | 0.964 | - | - |  | 87 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>distilled_patch16_384 | 0.851 | 0.973 | - | - |  | 88 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_384_pretrained.pdparams) |
 |  |  |  |  |  |  |  |  |
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 PaddleClas is a toolset for image classification tasks prepared for the industry and academia. It helps users train better computer vision models and apply them in real scenarios.
 
 **Recent update**
-- 2021.01.27 Add `ViT` and `DeiT` pretrained model, `ViT`'s Top-1 Acc on ImageNet-1k dataset reaches 81.05%, and `DeiT` reaches 85.5%.
+- 2021.01.27 Add `ViT` and `DeiT` pretrained model, `ViT`'s Top-1 Acc on ImageNet-1k dataset reaches 81.05%, and `DeiT` reaches 85.1%.
 - 2021.01.08 Add support for whl package and its usage, Model inference can be done by simply install paddleclas using pip.
 - 2020.12.16 Add support for TensorRT when using cpp inference to obain more obvious acceleration.
 - 2020.12.06 Add `SE_HRNet_W64_C_ssld` pretrained model, whose Top-1 Acc on ImageNet-1k dataset reaches 84.75%.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 PaddleClas is a toolset for image classification tasks prepared for the industry and academia. It helps users train better computer vision models and apply them in real scenarios.
 
 **Recent update**
-- 2021.01.27 Add `ViT` and `DeiT` pretrained model, `ViT`'s Top-1 Acc on ImageNet-1k dataset reaches 81.05%, and `DeiT` reaches 85.1%.
+- 2021.01.27 Add `ViT` and `DeiT` pretrained model, `ViT`'s Top-1 Acc on ImageNet-1k dataset reaches 85.13%, and `DeiT` reaches 85.1%.
 - 2021.01.08 Add support for whl package and its usage, Model inference can be done by simply install paddleclas using pip.
 - 2020.12.16 Add support for TensorRT when using cpp inference to obain more obvious acceleration.
 - 2020.12.06 Add `SE_HRNet_W64_C_ssld` pretrained model, whose Top-1 Acc on ImageNet-1k dataset reaches 84.75%.
@@ -361,13 +361,13 @@ Accuracy and inference time metrics of ViT and DeiT series models are shown as f
 
 | Model                    | Top-1 Acc | Top-5 Acc | time(ms)<br>bs=1 | time(ms)<br>bs=4 | Flops(G) | Params(M) | Download Address |
 |------------------------|-----------|-----------|------------------|------------------|----------|------------------------|------------------------|
-| ViT_small_<br/>patch16_224 | 0.7727  | 0.9319   | -                | -                |      |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_small_patch16_224_pretrained.pdparams) |
-| ViT_base_<br/>patch16_224 | 0.8176   | 0.9613   | -    | -                |     | 86 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_224_pretrained.pdparams) |
-| ViT_base_<br/>patch16_384 | 0.8393  | 0.9710   |    -              |      -           |         |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_384_pretrained.pdparams) |
-| ViT_base_<br/>patch32_384 | 0.8124   | 0.9598   | - | - |  |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch32_384_pretrained.pdparams) |
-| ViT_large_<br/>patch16_224 | 0.8325  | 0.9658   | - | - |  | 307 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_224_pretrained.pdparams) |
-| ViT_large_<br/>patch16_384 | 0.8507  | 0.9741  | - | - |  |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_384_pretrained.pdparams) |
-| ViT_large_<br/>patch32_384 | 0.8105   | 0.9596  | - | - |  |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch32_384_pretrained.pdparams) |
+| ViT_small_<br/>patch16_224 | 0.7769  | 0.9342   | -                | -                |      |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_small_patch16_224_pretrained.pdparams) |
+| ViT_base_<br/>patch16_224 | 0.8195   | 0.9617   | -    | -                |     | 86 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_224_pretrained.pdparams) |
+| ViT_base_<br/>patch16_384 | 0.8414  | 0.9717   |    -              |      -           |         |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_384_pretrained.pdparams) |
+| ViT_base_<br/>patch32_384 | 0.8176   | 0.9613   | - | - |  |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch32_384_pretrained.pdparams) |
+| ViT_large_<br/>patch16_224 | 0.8323  | 0.9650   | - | - |  | 307 | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_224_pretrained.pdparams) |
+| ViT_large_<br/>patch16_384 | 0.8513  | 0.9736  | - | - |  |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_384_pretrained.pdparams) |
+| ViT_large_<br/>patch32_384 | 0.8153   | 0.9608  | - | - |  |  | [Download link](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch32_384_pretrained.pdparams) |
 |                            |           |           |                  |                  |          |           |                                                              |
 
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -8,7 +8,7 @@
 
 
 **近期更新**
-- 2021.01.27 添加`ViT`与`DeiT`模型，在ImageNet-1k上，`ViT`模型Top-1 Acc可达81.05%，`DeiT`模型可达85.5%。
+- 2021.01.27 添加`ViT`与`DeiT`模型，在ImageNet-1k上，`ViT`模型Top-1 Acc可达81.05%，`DeiT`模型可达85.1%。
 - 2021.01.08 添加whl包及其使用说明，直接安装paddleclas whl包，即可快速完成模型预测。
 - 2020.12.16 添加对cpp预测的tensorRT支持，预测加速更明显。
 - 2020.12.06 添加`SE_HRNet_W64_C_ssld`模型，在ImageNet-1k上Top-1 Acc可达84.75%。
@@ -375,14 +375,14 @@ ViT（Vision Transformer）与DeiT（Data-efficient Image Transformers）系列�
 
 | 模型                  | Top-1 Acc | Top-5 Acc | time(ms)<br>bs=1 | time(ms)<br>bs=4 | Flops(G) | Params(M) | 下载地址 |
 |------------------------|-----------|-----------|------------------|------------------|----------|------------------------|------------------------|
-| DeiT_tiny_<br>patch16_224 | 0.709 | 0.906 | -                | -                |      | 5 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_patch16_224_pretrained.pdparams) |
-| DeiT_small_<br>patch16_224 | 0.794 | 0.948 | -    | -                |     | 22 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>patch16_224 | 0.816 | 0.955 |    -              |      -           |         | 86 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>patch16_384 | 0.831 | 0.962 | - | - |  | 87 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_384_pretrained.pdparams) |
-| DeiT_tiny_<br>distilled_patch16_224 | 0.736 | 0.915 | - | - |  | 6 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_distilled_patch16_224_pretrained.pdparams) |
-| DeiT_small_<br>distilled_patch16_224 | 0.810 | 0.953 | - | - |  | 22 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_distilled_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>distilled_patch16_224 | 0.830 | 0.963 | - | - |  | 87 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_224_pretrained.pdparams) |
-| DeiT_base_<br>distilled_patch16_384 | 0.855 | 0.974 | - | - |  | 88 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_384_pretrained.pdparams) |
+| DeiT_tiny_<br>patch16_224 | 0.718 | 0.910 | -                | -                |      | 5 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_patch16_224_pretrained.pdparams) |
+| DeiT_small_<br>patch16_224 | 0.796 | 0.949 | -    | -                |     | 22 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>patch16_224 | 0.817 | 0.957 |    -              |      -           |         | 86 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>patch16_384 | 0.830 | 0.962 | - | - |  | 87 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_patch16_384_pretrained.pdparams) |
+| DeiT_tiny_<br>distilled_patch16_224 | 0.741 | 0.918 | - | - |  | 6 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_tiny_distilled_patch16_224_pretrained.pdparams) |
+| DeiT_small_<br>distilled_patch16_224 | 0.809 | 0.953 | - | - |  | 22 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_small_distilled_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>distilled_patch16_224 | 0.831 | 0.964 | - | - |  | 87 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_224_pretrained.pdparams) |
+| DeiT_base_<br>distilled_patch16_384 | 0.851 | 0.973 | - | - |  | 88 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DeiT_base_distilled_patch16_384_pretrained.pdparams) |
 |  |  |  |  |  |  |  |  |
 
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -8,7 +8,7 @@
 
 
 **近期更新**
-- 2021.01.27 添加`ViT`与`DeiT`模型，在ImageNet-1k上，`ViT`模型Top-1 Acc可达81.05%，`DeiT`模型可达85.1%。
+- 2021.01.27 添加`ViT`与`DeiT`模型，在ImageNet-1k上，`ViT`模型Top-1 Acc可达85.13%，`DeiT`模型可达85.1%。
 - 2021.01.08 添加whl包及其使用说明，直接安装paddleclas whl包，即可快速完成模型预测。
 - 2020.12.16 添加对cpp预测的tensorRT支持，预测加速更明显。
 - 2020.12.06 添加`SE_HRNet_W64_C_ssld`模型，在ImageNet-1k上Top-1 Acc可达84.75%。
@@ -363,13 +363,13 @@ ViT（Vision Transformer）与DeiT（Data-efficient Image Transformers）系列�
 
 | 模型                  | Top-1 Acc | Top-5 Acc | time(ms)<br>bs=1 | time(ms)<br>bs=4 | Flops(G) | Params(M) | 下载地址 |
 |------------------------|-----------|-----------|------------------|------------------|----------|------------------------|------------------------|
-| ViT_small_<br/>patch16_224 | 0.7727  | 0.9319   | -                | -                |      |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_small_patch16_224_pretrained.pdparams) |
-| ViT_base_<br/>patch16_224 | 0.8176   | 0.9613   | -    | -                |     | 86 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_224_pretrained.pdparams) |
-| ViT_base_<br/>patch16_384 | 0.8393  | 0.9710   |    -              |      -           |         |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_384_pretrained.pdparams) |
-| ViT_base_<br/>patch32_384 | 0.8124   | 0.9598   | - | - |  |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch32_384_pretrained.pdparams) |
-| ViT_large_<br/>patch16_224 | 0.8325  | 0.9658   | - | - |  | 307 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_224_pretrained.pdparams) |
-| ViT_large_<br/>patch16_384 | 0.8507  | 0.9741  | - | - |  |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_384_pretrained.pdparams) |
-| ViT_large_<br/>patch32_384 | 0.8105   | 0.9596  | - | - |  |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch32_384_pretrained.pdparams) |
+| ViT_small_<br/>patch16_224 | 0.7769  | 0.9342   | -                | -                |      |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_small_patch16_224_pretrained.pdparams) |
+| ViT_base_<br/>patch16_224 | 0.8195   | 0.9617   | -    | -                |     | 86 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_224_pretrained.pdparams) |
+| ViT_base_<br/>patch16_384 | 0.8414  | 0.9717   |    -              |      -           |         |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch16_384_pretrained.pdparams) |
+| ViT_base_<br/>patch32_384 | 0.8176   | 0.9613   | - | - |  |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_base_patch32_384_pretrained.pdparams) |
+| ViT_large_<br/>patch16_224 | 0.8323  | 0.9650   | - | - |  | 307 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_224_pretrained.pdparams) |
+| ViT_large_<br/>patch16_384 | 0.8513  | 0.9736  | - | - |  |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch16_384_pretrained.pdparams) |
+| ViT_large_<br/>patch32_384 | 0.8153   | 0.9608  | - | - |  |  | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ViT_large_patch32_384_pretrained.pdparams) |
 |                            |           |           |                  |                  |          |           |                                                              |
 
 

--- a/configs/DeiT/DeiT_base_distilled_patch16_224.yaml
+++ b/configs/DeiT/DeiT_base_distilled_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/DeiT/DeiT_base_distilled_patch16_384.yaml
+++ b/configs/DeiT/DeiT_base_distilled_patch16_384.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 426
+            resize_short: 426
         - CropImage:
             size: 384
         - NormalizeImage:

--- a/configs/DeiT/DeiT_base_patch16_224.yaml
+++ b/configs/DeiT/DeiT_base_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/DeiT/DeiT_base_patch16_384.yaml
+++ b/configs/DeiT/DeiT_base_patch16_384.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 426
+            resize_short: 426
         - CropImage:
             size: 384
         - NormalizeImage:

--- a/configs/DeiT/DeiT_small_distilled_patch16_224.yaml
+++ b/configs/DeiT/DeiT_small_distilled_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/DeiT/DeiT_small_patch16_224.yaml
+++ b/configs/DeiT/DeiT_small_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/DeiT/DeiT_tiny_distilled_patch16_224.yaml
+++ b/configs/DeiT/DeiT_tiny_distilled_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/DeiT/DeiT_tiny_patch16_224.yaml
+++ b/configs/DeiT/DeiT_tiny_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_base_patch16_224.yaml
+++ b/configs/VisionTransformer/ViT_base_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_base_patch16_384.yaml
+++ b/configs/VisionTransformer/ViT_base_patch16_384.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 384
+            resize_short: 384
         - CropImage:
             size: 384
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_base_patch32_384.yaml
+++ b/configs/VisionTransformer/ViT_base_patch32_384.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 384
+            resize_short: 384
         - CropImage:
             size: 384
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_huge_patch16_224.yaml
+++ b/configs/VisionTransformer/ViT_huge_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_huge_patch32_384.yaml
+++ b/configs/VisionTransformer/ViT_huge_patch32_384.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 384
+            resize_short: 384
         - CropImage:
             size: 384
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_large_patch16_224.yaml
+++ b/configs/VisionTransformer/ViT_large_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_large_patch16_384.yaml
+++ b/configs/VisionTransformer/ViT_large_patch16_384.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 384
+            resize_short: 384
         - CropImage:
             size: 384
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_large_patch32_384.yaml
+++ b/configs/VisionTransformer/ViT_large_patch32_384.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 384
+            resize_short: 384
         - CropImage:
             size: 384
         - NormalizeImage:

--- a/configs/VisionTransformer/ViT_small_patch16_224.yaml
+++ b/configs/VisionTransformer/ViT_small_patch16_224.yaml
@@ -63,7 +63,7 @@ VALID:
             to_np: False
             channel_first: False
         - ResizeImage:
-            size: 248
+            resize_short: 248
         - CropImage:
             size: 224
         - NormalizeImage:

--- a/docs/en/models/Transformer.md
+++ b/docs/en/models/Transformer.md
@@ -11,13 +11,13 @@ DeiT(Data-efficient Image Transformers) series models were proposed by Facebook 
 
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |
 |:--:|:--:|:--:|:--:|:--:|:--:|
-| ViT_small_patch16_224 | 0.7727 | 0.9319 | 0.7785 | 0.9342 |      |
-| ViT_base_patch16_224  | 0.8176 | 0.9613 | 0.8178 | 0.9613 |      |
-| ViT_base_patch16_384  | 0.8393 | 0.9710 | 0.8420 | 0.9722 |      |
-| ViT_base_patch32_384  | 0.8124 | 0.9598 | 0.8166 | 0.9613 |      |
-| ViT_large_patch16_224 | 0.8325 | 0.9658 | 0.8306 | 0.9644 |      |
-| ViT_large_patch16_384 | 0.8507 | 0.9741 | 0.8517 | 0.9736 |      |
-| ViT_large_patch32_384 | 0.8105 | 0.9596 | 0.815  | -      |      |
+| ViT_small_patch16_224 | 0.7769 | 0.9342 | 0.7785 | 0.9342 |      |
+| ViT_base_patch16_224  | 0.8195 | 0.9617 | 0.8178 | 0.9613 |      |
+| ViT_base_patch16_384  | 0.8414 | 0.9717 | 0.8420 | 0.9722 |      |
+| ViT_base_patch32_384  | 0.8176 | 0.9613 | 0.8166 | 0.9613 |      |
+| ViT_large_patch16_224 | 0.8323 | 0.9650 | 0.8306 | 0.9644 |      |
+| ViT_large_patch16_384 | 0.8513 | 0.9736 | 0.8517 | 0.9736 |      |
+| ViT_large_patch32_384 | 0.8153 | 0.9608 | 0.815  | -      |      |
 
 
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |

--- a/docs/en/models/Transformer.md
+++ b/docs/en/models/Transformer.md
@@ -12,26 +12,24 @@ DeiT(Data-efficient Image Transformers) series models were proposed by Facebook 
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |
 |:--:|:--:|:--:|:--:|:--:|:--:|
 | ViT_small_patch16_224 | 0.7727 | 0.9319 | 0.7785 | 0.9342 |      |
-| ViT_base_patch16_224 | 0.8176 | 0.9613 | 0.8178 | 0.9613 |      |
-| ViT_base_patch16_384 | 0.8393 | 0.9710 | 0.8420 | 0.9722 |      |
-| ViT_base_patch32_384 | 0.8124 | 0.9598 | 0.8166 | 0.9613 |  |
-| ViT_large_patch16_224 | 0.8325 | 0.9658 | 0.8306 | 0.9644 |  |
-| ViT_large_patch16_384 | 0.8507 | 0.9741 | 0.8517 | 0.9736 |  |
-| ViT_large_patch32_384 | 0.8105 | 0.9596 | 0.815 | - |  |
-|                       |        |        |                   |                   |              |
+| ViT_base_patch16_224  | 0.8176 | 0.9613 | 0.8178 | 0.9613 |      |
+| ViT_base_patch16_384  | 0.8393 | 0.9710 | 0.8420 | 0.9722 |      |
+| ViT_base_patch32_384  | 0.8124 | 0.9598 | 0.8166 | 0.9613 |      |
+| ViT_large_patch16_224 | 0.8325 | 0.9658 | 0.8306 | 0.9644 |      |
+| ViT_large_patch16_384 | 0.8507 | 0.9741 | 0.8517 | 0.9736 |      |
+| ViT_large_patch32_384 | 0.8105 | 0.9596 | 0.815  | -      |      |
 
 
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |
 |:--:|:--:|:--:|:--:|:--:|:--:|
-| DeiT_tiny_patch16_224        | 0.709 | 0.906 | 0.722 | 0.911 |      |
-| DeiT_small_patch16_224        | 0.794 | 0.948 | 0.799 | 0.950 |      |
-| DeiT_base_patch16_224        | 0.816 | 0.955 | 0.818 | 0.956 |      |
-| DeiT_base_patch16_384 | 0.831 | 0.962 | 0.829 | 0.972 |  |
-| DeiT_tiny_distilled_patch16_224 | 0.736 | 0.915 | 0.745 | 0.919 |  |
-| DeiT_small_distilled_patch16_224 | 0.810 | 0.953 | 0.812 | 0.954 |  |
-| DeiT_base_distilled_patch16_224 | 0.830 | 0.963 | 0.834 | 0.965 |  |
-| DeiT_base_distilled_patch16_384 | 0.855 | 0.974 | 0.852 | 0.972 |  |
-|  |  | |  | |  |
+| DeiT_tiny_patch16_224            | 0.718 | 0.910 | 0.722 | 0.911 |      |
+| DeiT_small_patch16_224           | 0.796 | 0.949 | 0.799 | 0.950 |      |
+| DeiT_base_patch16_224            | 0.817 | 0.957 | 0.818 | 0.956 |      |
+| DeiT_base_patch16_384            | 0.830 | 0.962 | 0.829 | 0.972 |      |
+| DeiT_tiny_distilled_patch16_224  | 0.741 | 0.918 | 0.745 | 0.919 |      |
+| DeiT_small_distilled_patch16_224 | 0.809 | 0.953 | 0.812 | 0.954 |      |
+| DeiT_base_distilled_patch16_224  | 0.831 | 0.964 | 0.834 | 0.965 |      |
+| DeiT_base_distilled_patch16_384  | 0.851 | 0.973 | 0.852 | 0.972 |      |
 
 
 Params, FLOPs, Inference speed and other information are coming soon.

--- a/docs/zh_CN/models/Transformer.md
+++ b/docs/zh_CN/models/Transformer.md
@@ -13,13 +13,13 @@ DeiT（Data-efficient Image Transformers）系列模型是由FaceBook在2020年�
 
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |
 |:--:|:--:|:--:|:--:|:--:|:--:|
-| ViT_small_patch16_224 | 0.7727 | 0.9319 | 0.7785 | 0.9342 |      |
-| ViT_base_patch16_224  | 0.8176 | 0.9613 | 0.8178 | 0.9613 |      |
-| ViT_base_patch16_384  | 0.8393 | 0.9710 | 0.8420 | 0.9722 |      |
-| ViT_base_patch32_384  | 0.8124 | 0.9598 | 0.8166 | 0.9613 |      |
-| ViT_large_patch16_224 | 0.8325 | 0.9658 | 0.8306 | 0.9644 |      |
-| ViT_large_patch16_384 | 0.8507 | 0.9741 | 0.8517 | 0.9736 |      |
-| ViT_large_patch32_384 | 0.8105 | 0.9596 | 0.815  | -      |      |
+| ViT_small_patch16_224 | 0.7769 | 0.9342 | 0.7785 | 0.9342 |      |
+| ViT_base_patch16_224  | 0.8195 | 0.9617 | 0.8178 | 0.9613 |      |
+| ViT_base_patch16_384  | 0.8414 | 0.9717 | 0.8420 | 0.9722 |      |
+| ViT_base_patch32_384  | 0.8176 | 0.9613 | 0.8166 | 0.9613 |      |
+| ViT_large_patch16_224 | 0.8323 | 0.9650 | 0.8306 | 0.9644 |      |
+| ViT_large_patch16_384 | 0.8513 | 0.9736 | 0.8517 | 0.9736 |      |
+| ViT_large_patch32_384 | 0.8153 | 0.9608 | 0.815  | -      |      |
 
 
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |

--- a/docs/zh_CN/models/Transformer.md
+++ b/docs/zh_CN/models/Transformer.md
@@ -14,25 +14,23 @@ DeiT（Data-efficient Image Transformers）系列模型是由FaceBook在2020年�
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |
 |:--:|:--:|:--:|:--:|:--:|:--:|
 | ViT_small_patch16_224 | 0.7727 | 0.9319 | 0.7785 | 0.9342 |      |
-| ViT_base_patch16_224 | 0.8176 | 0.9613 | 0.8178 | 0.9613 |      |
-| ViT_base_patch16_384 | 0.8393 | 0.9710 | 0.8420 | 0.9722 |      |
-| ViT_base_patch32_384 | 0.8124 | 0.9598 | 0.8166 | 0.9613 |  |
-| ViT_large_patch16_224 | 0.8325 | 0.9658 | 0.8306 | 0.9644 |  |
-| ViT_large_patch16_384 | 0.8507 | 0.9741 | 0.8517 | 0.9736 |  |
-| ViT_large_patch32_384 | 0.8105 | 0.9596 | 0.815 | - |  |
-|                       |        |        |                   |                   |              |
+| ViT_base_patch16_224  | 0.8176 | 0.9613 | 0.8178 | 0.9613 |      |
+| ViT_base_patch16_384  | 0.8393 | 0.9710 | 0.8420 | 0.9722 |      |
+| ViT_base_patch32_384  | 0.8124 | 0.9598 | 0.8166 | 0.9613 |      |
+| ViT_large_patch16_224 | 0.8325 | 0.9658 | 0.8306 | 0.9644 |      |
+| ViT_large_patch16_384 | 0.8507 | 0.9741 | 0.8517 | 0.9736 |      |
+| ViT_large_patch32_384 | 0.8105 | 0.9596 | 0.815  | -      |      |
 
 
 | Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPS<br>(G) |
 |:--:|:--:|:--:|:--:|:--:|:--:|
-| DeiT_tiny_patch16_224        | 0.709 | 0.906 | 0.722 | 0.911 |      |
-| DeiT_small_patch16_224        | 0.794 | 0.948 | 0.799 | 0.950 |      |
-| DeiT_base_patch16_224        | 0.816 | 0.955 | 0.818 | 0.956 |      |
-| DeiT_base_patch16_384 | 0.831 | 0.962 | 0.829 | 0.972 |  |
-| DeiT_tiny_distilled_patch16_224 | 0.736 | 0.915 | 0.745 | 0.919 |  |
-| DeiT_small_distilled_patch16_224 | 0.810 | 0.953 | 0.812 | 0.954 |  |
-| DeiT_base_distilled_patch16_224 | 0.830 | 0.963 | 0.834 | 0.965 |  |
-| DeiT_base_distilled_patch16_384 | 0.855 | 0.974 | 0.852 | 0.972 |  |
-|  |  | |  | |  |
+| DeiT_tiny_patch16_224            | 0.718 | 0.910 | 0.722 | 0.911 |      |
+| DeiT_small_patch16_224           | 0.796 | 0.949 | 0.799 | 0.950 |      |
+| DeiT_base_patch16_224            | 0.817 | 0.957 | 0.818 | 0.956 |      |
+| DeiT_base_patch16_384            | 0.830 | 0.962 | 0.829 | 0.972 |      |
+| DeiT_tiny_distilled_patch16_224  | 0.741 | 0.918 | 0.745 | 0.919 |      |
+| DeiT_small_distilled_patch16_224 | 0.809 | 0.953 | 0.812 | 0.954 |      |
+| DeiT_base_distilled_patch16_224  | 0.831 | 0.964 | 0.834 | 0.965 |      |
+| DeiT_base_distilled_patch16_384  | 0.851 | 0.973 | 0.852 | 0.972 |      |
 
 关于Params、FLOPs、Inference speed等信息，敬请期待。


### PR DESCRIPTION
更新模型config 统一resize为 resize_short和参考代码保持一致，还有就是推理脚本暂时没有直接resize的选项，原来那么配置不太好

更新模型精度信息，使用resize_short相比之前精度与标称精度更加接近

RepVGG的精度正在测试之中，之后更新README