### PR TITLE
fix oom for batch_size=208

### DIFF
--- a/tools/static/train.py
+++ b/tools/static/train.py
@@ -68,7 +68,7 @@ def main(args):
     if 'AMP' in config:
         AMP_RELATED_FLAGS_SETTING = {
             'FLAGS_cudnn_exhaustive_search': 1,
-            'FLAGS_conv_workspace_size_limit': 4000,
+            'FLAGS_conv_workspace_size_limit': 1500,
             'FLAGS_cudnn_batchnorm_spatial_persistent': 1,
             'FLAGS_max_inplace_grad_add': 8,
         }


### PR DESCRIPTION
FLAGS_conv_workspace_size_limit用于设置卷积算法搜索的workspace，在卷积算法搜素时需要提前分配FLAGS_conv_workspace_size_limit大小的内存，但是模型中该flag值设置过高并不合理，因为实际需要用的workspace是小于该值的。

由于 [Paddle #30959](https://github.com/PaddlePaddle/Paddle/pull/30959)对forward和input_grad也开启了search功能，较高的workspace设置导致混合精度训练中 ResNet50 BS=208会发生OOM。

解决方案：通过调整模型flag值到1500避免OOM，自测性能与设置为4000时一致，以下测试多次发现速度并不是很稳定，绝对值有轻微波动。

- Paddle #30959 之前，并且FLAGS_conv_workspace_size_limit=4000，use_pure_fp16=false，BS=208
```
2021-02-26 08:36:07,107 - INFO - epoch:0   train step:10   top1: 0.0000 top5: 0.0000 loss: 10.2210 lr: 0.100000, batch_cost: 0.15447 s, reader_cost: 0.07293 s, ips: 1346.54596 images/sec.
2021-02-26 08:36:08,655 - INFO - epoch:0   train step:20   top1: 0.0048 top5: 0.0048 loss:  8.4058 lr: 0.100000, batch_cost: 0.15457 s, reader_cost: 0.06762 s, ips: 1345.65904 images/sec.
2021-02-26 08:36:10,195 - INFO - epoch:0   train step:30   top1: 0.0048 top5: 0.0144 loss:  7.3488 lr: 0.100000, batch_cost: 0.15429 s, reader_cost: 0.05602 s, ips: 1348.07691 images/sec.
2021-02-26 08:36:11,737 - INFO - epoch:0   train step:40   top1: 0.0000 top5: 0.0000 loss:  6.9969 lr: 0.100000, batch_cost: 0.15423 s, reader_cost: 0.05499 s, ips: 1348.67814 images/sec.
2021-02-26 08:36:13,279 - INFO - epoch:0   train step:50   top1: 0.0000 top5: 0.0048 loss:  8.1607 lr: 0.100000, batch_cost: 0.15420 s, reader_cost: 0.05671 s, ips: 1348.85882 images/sec.
2021-02-26 08:36:14,833 - INFO - epoch:0   train step:60   top1: 0.0000 top5: 0.0144 loss:  7.0166 lr: 0.100000, batch_cost: 0.15439 s, reader_cost: 0.05620 s, ips: 1347.23218 images/sec.
2021-02-26 08:36:16,373 - INFO - epoch:0   train step:70   top1: 0.0000 top5: 0.0000 loss:  6.9536 lr: 0.100000, batch_cost: 0.15431 s, reader_cost: 0.05477 s, ips: 1347.92169 images/sec.
2021-02-26 08:36:17,914 - INFO - epoch:0   train step:80   top1: 0.0000 top5: 0.0000 loss:  6.9080 lr: 0.100000, batch_cost: 0.15428 s, reader_cost: 0.05430 s, ips: 1348.23040 images/sec.
2021-02-26 08:36:19,443 - INFO - epoch:0   train step:90   top1: 0.0048 top5: 0.0096 loss:  6.9130 lr: 0.100000, batch_cost: 0.15410 s, reader_cost: 0.05194 s, ips: 1349.77375 images/sec.
2021-02-26 08:36:20,975 - INFO - epoch:0   train step:100  top1: 0.0048 top5: 0.0144 loss:  6.9152 lr: 0.100000, batch_cost: 0.15399 s, reader_cost: 0.05246 s, ips: 1350.76708 images/sec.
```
- Paddle #30959 之前，并且FLAGS_conv_workspace_size_limit=1500，use_pure_fp16=false，BS=208
```
2021-02-26 08:44:06,222 - INFO - epoch:0   train step:10   top1: 0.0000 top5: 0.0048 loss:  8.7279 lr: 0.100000, batch_cost: 0.15575 s, reader_cost: 0.05908 s, ips: 1335.48445 images/sec.
2021-02-26 08:44:07,777 - INFO - epoch:0   train step:20   top1: 0.0000 top5: 0.0000 loss:  8.6422 lr: 0.100000, batch_cost: 0.15554 s, reader_cost: 0.06299 s, ips: 1337.29692 images/sec.
2021-02-26 08:44:09,327 - INFO - epoch:0   train step:30   top1: 0.0000 top5: 0.0144 loss:  7.3046 lr: 0.100000, batch_cost: 0.15530 s, reader_cost: 0.06058 s, ips: 1339.37490 images/sec.
2021-02-26 08:44:10,879 - INFO - epoch:0   train step:40   top1: 0.0000 top5: 0.0000 loss:  7.0926 lr: 0.100000, batch_cost: 0.15522 s, reader_cost: 0.05988 s, ips: 1340.00733 images/sec.
2021-02-26 08:44:12,425 - INFO - epoch:0   train step:50   top1: 0.0000 top5: 0.0000 loss:  6.9130 lr: 0.100000, batch_cost: 0.15506 s, reader_cost: 0.05631 s, ips: 1341.42998 images/sec.
2021-02-26 08:44:13,973 - INFO - epoch:0   train step:60   top1: 0.0000 top5: 0.0000 loss:  6.9070 lr: 0.100000, batch_cost: 0.15499 s, reader_cost: 0.05488 s, ips: 1342.00101 images/sec.
2021-02-26 08:44:15,516 - INFO - epoch:0   train step:70   top1: 0.0000 top5: 0.0048 loss:  7.4147 lr: 0.100000, batch_cost: 0.15487 s, reader_cost: 0.05338 s, ips: 1343.08648 images/sec.
2021-02-26 08:44:17,062 - INFO - epoch:0   train step:80   top1: 0.0000 top5: 0.0144 loss:  6.9389 lr: 0.100000, batch_cost: 0.15481 s, reader_cost: 0.05341 s, ips: 1343.55595 images/sec.
2021-02-26 08:44:18,603 - INFO - epoch:0   train step:90   top1: 0.0048 top5: 0.0096 loss:  6.9106 lr: 0.100000, batch_cost: 0.15472 s, reader_cost: 0.05189 s, ips: 1344.32977 images/sec.
2021-02-26 08:44:20,151 - INFO - epoch:0   train step:100  top1: 0.0048 top5: 0.0144 loss:  6.9127 lr: 0.100000, batch_cost: 0.15472 s, reader_cost: 0.05275 s, ips: 1344.37579 images/sec.
```

**结论：Paddle #30959前，模型中该flag设置为4000或者1500，性能持平**

- 使用Paddle #30959 ，并且FLAGS_conv_workspace_size_limit=1500，use_pure_fp16=false，BS=208
```
2021-02-26 08:55:28 INFO: epoch:0   train step:10   top1: 0.0000 top5: 0.0000 loss:  8.4179 lr: 0.100000, batch_cost: 0.15430 s, reader_cost: 0.05769 s, ips: 1347.99405 images/sec.
2021-02-26 08:55:30 INFO: epoch:0   train step:20   top1: 0.0048 top5: 0.0096 loss: 12.3482 lr: 0.100000, batch_cost: 0.15470 s, reader_cost: 0.05880 s, ips: 1344.51790 images/sec.
2021-02-26 08:55:31 INFO: epoch:0   train step:30   top1: 0.0000 top5: 0.0096 loss:  7.0055 lr: 0.100000, batch_cost: 0.15450 s, reader_cost: 0.05455 s, ips: 1346.30238 images/sec.
2021-02-26 08:55:33 INFO: epoch:0   train step:40   top1: 0.0000 top5: 0.0048 loss:  7.0104 lr: 0.100000, batch_cost: 0.15438 s, reader_cost: 0.05234 s, ips: 1347.30053 images/sec.
2021-02-26 08:55:34 INFO: epoch:0   train step:50   top1: 0.0000 top5: 0.0000 loss:  6.9643 lr: 0.100000, batch_cost: 0.15425 s, reader_cost: 0.05534 s, ips: 1348.41684 images/sec.
2021-02-26 08:55:36 INFO: epoch:0   train step:60   top1: 0.0000 top5: 0.0000 loss:  6.9675 lr: 0.100000, batch_cost: 0.15425 s, reader_cost: 0.05367 s, ips: 1348.42947 images/sec.
2021-02-26 08:55:37 INFO: epoch:0   train step:70   top1: 0.0096 top5: 0.0144 loss:  6.9253 lr: 0.100000, batch_cost: 0.15423 s, reader_cost: 0.05122 s, ips: 1348.65649 images/sec.
2021-02-26 08:55:39 INFO: epoch:0   train step:80   top1: 0.0000 top5: 0.0048 loss:  6.9097 lr: 0.100000, batch_cost: 0.15428 s, reader_cost: 0.05219 s, ips: 1348.19180 images/sec.
2021-02-26 08:55:40 INFO: epoch:0   train step:90   top1: 0.0000 top5: 0.0096 loss:  6.9300 lr: 0.100000, batch_cost: 0.15430 s, reader_cost: 0.05174 s, ips: 1348.05775 images/sec.
2021-02-26 08:55:42 INFO: epoch:0   train step:100  top1: 0.0048 top5: 0.0144 loss:  6.9218 lr: 0.100000, batch_cost: 0.15444 s, reader_cost: 0.05067 s, ips: 1346.79309 images/sec.
```
**结论：使用Paddle #30959，并且调小flag值与原始速度基本持平**
