### PR TITLE
Support fp16 training for ResNeXt101_32x4d

### DIFF
--- a/configs/ResNeXt/ResNeXt101_32x4d_fp16.yaml
+++ b/configs/ResNeXt/ResNeXt101_32x4d_fp16.yaml
@@ -1,0 +1,91 @@
+mode: 'train'
+ARCHITECTURE:
+    name: 'ResNeXt101_32x4d'
+
+pretrained_model: ""
+model_save_dir: "./output/"
+classes_num: 1000
+total_images: 1281167
+save_interval: 1
+validate: True
+valid_interval: 1
+epochs: 120
+topk: 5
+image_shape: [4, 224, 224]
+
+use_dali: True
+use_gpu: True
+data_format: "NCHW"
+image_channel: &image_channel 4
+image_shape: [*image_channel, 224, 224]
+
+use_mix: False
+ls_epsilon: -1
+
+# mixed precision training
+AMP:
+    scale_loss: 128.0
+    use_dynamic_loss_scaling: True
+    use_pure_fp16: &use_pure_fp16 True
+
+LEARNING_RATE:
+    function: 'Piecewise'          
+    params:                   
+        lr: 0.1               
+        decay_epochs: [30, 60, 90] 
+        gamma: 0.1 
+
+OPTIMIZER:
+    function: 'Momentum'
+    params:
+        momentum: 0.9
+        multi_precision: *use_pure_fp16
+    regularizer:
+        function: 'L2'
+        factor: 0.000100
+
+TRAIN:
+    batch_size: 256
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/train_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1./255.
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+            output_fp16: *use_pure_fp16
+            channel_num: *image_channel
+        - ToCHWImage:
+
+VALID:
+    batch_size: 64
+    num_workers: 4
+    file_list: "./dataset/ILSVRC2012/val_list.txt"
+    data_dir: "./dataset/ILSVRC2012/"
+    shuffle_seed: 0
+    transforms:
+        - DecodeImage:
+            to_rgb: True
+            to_np: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+        - ToCHWImage:


### PR DESCRIPTION
Support mixed precision training for ResNeXt101_32x4d

Running command：

```python
export CUDA_VISIBLE_DEVICES=5
export FLAGS_fraction_of_gpu_memory_to_use=0.8

batch_size=128
python static/train.py -c ../configs/ResNeXt/ResNeXt101_32x4d_fp16.yaml \
        -o TRAIN.batch_size=${batch_size} \
        -o epochs=120 \
        -o validate=True \
        -o is_distributed=False \
        -o TRAIN.data_dir=/datasets/ILSVRC2012 \
        -o TRAIN.file_list=/datasets/ILSVRC2012/train_list.txt \
        -o VALID.data_dir=/datasets/ILSVRC2012 \
        -o VALID.file_list=/datasets/ILSVRC2012/val_list.txt \
        -o TRAIN.num_workers=0
```

Training permormance (image per second): 
fp32
![image](https://user-images.githubusercontent.com/46740794/112811284-7bc2b800-90ae-11eb-9c26-d4c808b76110.png)
fp16:
set FLAGS_cudnn_exhaustive_search=0:
![image](https://user-images.githubusercontent.com/46740794/112810504-ac562200-90ad-11eb-9bb4-38b5e14340ae.png)
set FLAGS cudnn_exhaustive_search=1:
![image](https://user-images.githubusercontent.com/46740794/112810790-fc34e900-90ad-11eb-9ec4-0cde23e07b9b.png)



