### PR TITLE
[Kunlun]add multi xpu support for PaddleClas

### DIFF
--- a/tools/static/train.py
+++ b/tools/static/train.py
@@ -119,11 +119,12 @@ def main(args):
     init_model(config, train_prog, exe)
 
     if 'AMP' in config and config.AMP.get("use_pure_fp16", False):
-        optimizer.amp_init(place,
-                scope=paddle.static.global_scope(),
-                test_program=valid_prog if config.validate else None)
+        optimizer.amp_init(
+            place,
+            scope=paddle.static.global_scope(),
+            test_program=valid_prog if config.validate else None)
 
-    if not config.get("is_distributed", True) and not use_xpu:
+    if not config.get("is_distributed", True):
         compiled_train_prog = program.compile(
             config, train_prog, loss_name=train_fetchs["loss"][0].name)
     else:
@@ -133,10 +134,7 @@ def main(args):
         train_dataloader = Reader(config, 'train', places=place)()
         if config.validate and paddle.distributed.get_rank() == 0:
             valid_dataloader = Reader(config, 'valid', places=place)()
-            if use_xpu:
-                compiled_valid_prog = valid_prog
-            else:
-                compiled_valid_prog = program.compile(config, valid_prog)
+            compiled_valid_prog = program.compile(config, valid_prog)
     else:
         assert use_gpu is True, "DALI only support gpu, please set use_gpu to True!"
         import dali


### PR DESCRIPTION
add add multi xpu support for PaddleClas static mode

example:

```
python3.7 -m paddle.distributed.launch \
	--xpus="0,1" \
	--log_dir log \
	tools/static/train.py \
	-c ./configs/quick_start/ResNet50_vd_finetune_kunlun.yaml \
	-o is_distributed=False \
	-o use_gpu=False \
	-o use_xpu=True \
```

log as following 
```
2021-04-13 12:18:20,931 - INFO - epoch:15  train step:0    top1: 1.0000 top5: 1.0000 loss:  0.2552 lr: 0.000545, batch_cost: 0.26392 s, reader_cost: 0.08020 s, ips: 37.89057 images/sec.
2021-04-13 12:18:22,764 - INFO - epoch:15  train step:10   top1: 1.0000 top5: 1.0000 loss:  0.2997 lr: 0.000505, batch_cost: 0.18307 s, reader_cost: 0.00005 s, ips: 54.62263 images/sec.
2021-04-13 12:18:24,598 - INFO - epoch:15  train step:20   top1: 0.9000 top5: 0.9000 loss:  0.4557 lr: 0.000466, batch_cost: 0.18320 s, reader_cost: 0.00005 s, ips: 54.58460 images/sec.
2021-04-13 12:18:26,432 - INFO - epoch:15  train step:30   top1: 0.9000 top5: 0.9000 loss:  0.7909 lr: 0.000429, batch_cost: 0.18327 s, reader_cost: 0.00005 s, ips: 54.56479 images/sec.
2021-04-13 12:18:28,265 - INFO - epoch:15  train step:40   top1: 0.9000 top5: 1.0000 loss:  0.3415 lr: 0.000393, batch_cost: 0.18324 s, reader_cost: 0.00005 s, ips: 54.57293 images/sec.
2021-04-13 12:18:30,097 - INFO - epoch:15  train step:50   top1: 0.8000 top5: 1.0000 loss:  0.7302 lr: 0.000358, batch_cost: 0.18323 s, reader_cost: 0.00005 s, ips: 54.57625 images/sec.
2021-04-13 12:18:30,114 - INFO - END epoch:15  train top1: 0.9431 top5: 0.9824 loss:  0.3570  batch_cost: 0.18323 s, reader_cost: 0.00005 s, batch_cost_sum: 8.42857 s, ips: 54.57625 images/sec.
2021-04-13 12:18:30,302 - INFO - valid step:0    top1: 1.0000 top5: 1.0000 loss:  0.0526 lr: 0.000000, batch_cost: 0.17515 s, reader_cost: 0.09531 s, ips: 57.09356 images/sec.
2021-04-13 12:18:31,096 - INFO - valid step:10   top1: 0.9000 top5: 1.0000 loss:  0.2438 lr: 0.000000, batch_cost: 0.07775 s, reader_cost: 0.00007 s, ips: 128.61295 images/sec.
2021-04-13 12:18:31,879 - INFO - valid step:20   top1: 1.0000 top5: 1.0000 loss:  0.1705 lr: 0.000000, batch_cost: 0.07803 s, reader_cost: 0.00007 s, ips: 128.16231 images/sec.
2021-04-13 12:18:32,664 - INFO - valid step:30   top1: 1.0000 top5: 1.0000 loss:  0.0314 lr: 0.000000, batch_cost: 0.07815 s, reader_cost: 0.00007 s, ips: 127.96623 images/sec.
2021-04-13 12:18:33,442 - INFO - valid step:40   top1: 0.9000 top5: 1.0000 loss:  0.4295 lr: 0.000000, batch_cost: 0.07802 s, reader_cost: 0.00007 s, ips: 128.17157 images/sec.
2021-04-13 12:18:34,323 - INFO - valid step:50   top1: 0.9000 top5: 1.0000 loss:  0.3594 lr: 0.000000, batch_cost: 0.08020 s, reader_cost: 0.00008 s, ips: 124.69134 images/sec.
2021-04-13 12:18:34,347 - INFO - END valid top1: 0.9255 top5: 0.9843 loss:  0.3188  batch_cost: 0.08020 s, reader_cost: 0.00008 s, batch_cost_sum: 3.68911 s, ips: 124.69134 images/sec.
2021-04-13 12:18:34,347 - INFO - The best top1 acc 0.92549, in epoch: 15
2021-04-13 12:18:36,183 - INFO - Already save model in ./output/ResNet50_vd/best_model
2021-04-13 12:18:37,967 - INFO - Already save model in ./output/ResNet50_vd/15
```
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/12137504/114551243-b5421880-9c95-11eb-9109-51ebe1b99d8a.png">
