### PR TITLE
[Kunlun]add multi xpu support for PaddleClas about dygraph

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -79,10 +79,10 @@ def main(args):
         config, parameter_list=net.parameters())
 
     dp_net = net
-    # if config["use_data_parallel"]:
-    #     find_unused_parameters = config.get("find_unused_parameters", False)
-    #     dp_net = paddle.DataParallel(
-    #         net, find_unused_parameters=find_unused_parameters)
+    if config["use_data_parallel"]:
+        find_unused_parameters = config.get("find_unused_parameters", False)
+        dp_net = paddle.DataParallel(
+            net, find_unused_parameters=find_unused_parameters)
 
     # load model from checkpoint or pretrained model
     init_model(config, net, optimizer)


### PR DESCRIPTION
add add multi xpu support for PaddleClas dygraph mode

example:
```
python3.7 -m paddle.distributed.launch \
	--xpus="0,1" \
	--log_dir log \
	tools/train.py \
	-c ./configs/quick_start/ResNet50_vd_finetune_kunlun.yaml \
	-o is_distributed=False \
	-o use_gpu=False \
	-o use_xpu=True \
```