### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML
 visualdl >= 2.0.0b
 scipy
 scikit-learn==0.23.2
+gast==0.3.3


### PR DESCRIPTION
Fix the error of tools/export_model.py, when the gast version != 0.3.3