### PR TITLE
fix export model eval

### DIFF
--- a/tools/export_model.py
+++ b/tools/export_model.py
@@ -47,6 +47,12 @@ class Net(paddle.nn.Layer):
         self.pre_net = net(class_dim=class_dim)
         self.model = model
 
+    def eval(self):
+        self.training = False
+        for layer in self.sublayers():
+            layer.training = False
+            layer.eval()
+
     def forward(self, inputs):
         x = self.pre_net(inputs)
         if self.model == "GoogLeNet":


### PR DESCRIPTION
1. att, in Paddle2.1, just the training flag is changed when model.eval() is called, so the sublayers' eval() process must be called explicitly.
2. fix error when export swin transformer models.