### PR TITLE
[CE] Support -o to_static flag to control training for benchmark

### DIFF
--- a/configs/MobileNetV1/MobileNetV1.yaml
+++ b/configs/MobileNetV1/MobileNetV1.yaml
@@ -2,6 +2,7 @@ mode: 'train'
 ARCHITECTURE:
     name: "MobileNetV1"
 
+support_to_static: True
 pretrained_model: ""
 model_save_dir: "./output/"
 classes_num: 1000
@@ -71,5 +72,3 @@ VALID:
             std: [0.229, 0.224, 0.225]
             order: ''
         - ToCHWImage:
-
-

--- a/configs/MobileNetV2/MobileNetV2.yaml
+++ b/configs/MobileNetV2/MobileNetV2.yaml
@@ -2,6 +2,7 @@ mode: 'train'
 ARCHITECTURE:
     name: "MobileNetV2"
 
+support_to_static: True
 pretrained_model: ""
 model_save_dir: "./output/"
 classes_num: 1000
@@ -70,5 +71,3 @@ VALID:
             std: [0.229, 0.224, 0.225]
             order: ''
         - ToCHWImage:
-
-

--- a/configs/ResNet/ResNet152.yaml
+++ b/configs/ResNet/ResNet152.yaml
@@ -2,6 +2,7 @@ mode: 'train'
 ARCHITECTURE:
     name: 'ResNet152'
 
+support_to_static: True
 pretrained_model: ""
 model_save_dir: "./output/"
 classes_num: 1000

--- a/configs/ResNet/ResNet50.yaml
+++ b/configs/ResNet/ResNet50.yaml
@@ -2,6 +2,7 @@ mode: 'train'
 ARCHITECTURE:
     name: 'ResNet50'
 
+support_to_static: True
 pretrained_model: ""
 model_save_dir: "./output/"
 classes_num: 1000

--- a/tools/train.py
+++ b/tools/train.py
@@ -95,9 +95,7 @@ def main(args):
     init_model(config, net, optimizer)
 
     # add for benchmark platform to test training speed of @to_static
-    to_static = config.get("to_static", False) and config.get(
-        "support_to_static", False)
-    if to_static:
+    if config.get("to_static", False) and config.get("support_to_static", False):
         dp_net = paddle.jit.to_static(dp_net)
         logger.info("Successfully to apply @to_static for training.")
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -94,6 +94,13 @@ def main(args):
     # load model from checkpoint or pretrained model
     init_model(config, net, optimizer)
 
+    # add for benchmark platform to test training speed of @to_static
+    to_static = config.get("to_static", False) and config.get(
+        "support_to_static", False)
+    if to_static:
+        dp_net = paddle.jit.to_static(dp_net)
+        logger.info("Successfully to apply @to_static for training.")
+
     train_dataloader = Reader(config, 'train', places=place)()
     if len(train_dataloader) <= 0:
         logger.error(


### PR DESCRIPTION
### What' New?

#### 1. 背景
目前 Benchamrk 平台上有静态图、动态图的训练数据监控，缺乏 动转静 @to_static 训练的性能监控，因此在 PaddleClas 动态图训练代码处进行了动转静支持。

#### 2. PR内容

选取 ResNet50、ResNet152、MobileNetV1、MobileNetV2为例，在 config.yaml 中添加 `support_to_static = True`（缺省则表示False）表示模型支持动转静。

同时支持训练时，通过 `-o to_static=True` 来开启动转静训练。

> 注：若yaml配置中没有 `support_to_static` 字段，或执行时未指定 `-o to_static=True`，则训练行为与现有逻辑保持一致。

#### 3. 自测验证

基于 PaddleClas 首页的 QuickStart 教程中的 ResNet50_vd 自测没有问题，测试命令如下：（需在yaml添加support_to_static）
```bash
python3 tools/train.py -c ./configs/quick_start/ResNet50_vd.yaml \
    -o use_gpu=False \
    -o validate=False \
    -o epochs=1 \
    -o print_interval=10 \
    -o TRAIN.batch_size=8 \
    -o to_static=True
```

#### 4. 模型影响面

**不会影响现有的模型**。

只有明确在yaml 文件中添加 `support_to_static: True` 才会支持 动转静训练。后续会推动模型陆续支持和打开此开关。