### PR TITLE
fix warning for index.so compliation

### DIFF
--- a/deploy/vector_search/interface.py
+++ b/deploy/vector_search/interface.py
@@ -29,7 +29,14 @@ if platform.system() == "Windows":
 else:
     lib_filename = "index.so"
 so_path = os.path.join(__dir__, lib_filename)
-lib = ctypes.cdll.LoadLibrary(so_path)
+try:
+    lib = ctypes.cdll.LoadLibrary(so_path)
+except Exception as ex:
+    readme_path = os.path.join(__dir__, "README.md")
+    print(
+        f"Error happened when load lib {so_path} with msg {ex},\nplease refer to {readme_path} to rebuild your library."
+    )
+    exit(-1)
 
 
 class IndexContext(Structure):


### PR DESCRIPTION
att, a demo error is as follows.

```
Error happened when load lib /Users/xxx/code/PaddleClas/deploy/vector_search/index.so with msg dlopen(/Users/xxx/code/PaddleClas/deploy/vector_search/index.so, 6): no suitable image found.  Did find:
	/Users/xxx/code/PaddleClas/deploy/vector_search/index.so: mach-o, but wrong architecture
	/Users/xxx/code/PaddleClas/deploy/vector_search/index.so: mach-o, but wrong architecture
, please refer to /Users/xxx/code/PaddleClas/deploy/vector_search/README.md to rebuild your library.
```