### PR TITLE
Support -o to_static flag to control training for benchmark 

### DIFF
--- a/ppcls/arch/__init__.py
+++ b/ppcls/arch/__init__.py
@@ -16,11 +16,14 @@ import copy
 import importlib
 
 import paddle.nn as nn
+from paddle.jit import to_static
+from paddle.static import InputSpec
 
 from . import backbone, gears
 from .backbone import *
 from .gears import build_gear
 from .utils import *
+from ppcls.utils import logger
 from ppcls.utils.save_load import load_dygraph_pretrain
 
 __all__ = ["build_model", "RecModel", "DistillationModel"]
@@ -32,6 +35,19 @@ def build_model(config):
     mod = importlib.import_module(__name__)
     arch = getattr(mod, model_type)(**config)
     return arch
+
+
+def apply_to_static(config, model):
+    support_to_static = config['Global'].get('to_static', False)
+
+    if support_to_static:
+        specs = None
+        if 'image_shape' in config['Global']:
+            specs = [InputSpec([None] + config['Global']['image_shape'])]
+        model = to_static(model, input_spec=specs)
+        logger.info("Successfully to apply @to_static with specs: {}".format(
+            specs))
+    return model
 
 
 class RecModel(nn.Layer):

--- a/ppcls/configs/ImageNet/MobileNetV1/MobileNetV1.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV1/MobileNetV1.yaml
@@ -14,6 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
+  # training model under @to_static
+  to_static: False
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/MobileNetV2/MobileNetV2.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV2/MobileNetV2.yaml
@@ -14,6 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
+  # training model under @to_static
+  to_static: False
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet101.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet101.yaml
@@ -14,6 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
+  # training model under @to_static
+  to_static: False
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet152.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet152.yaml
@@ -14,6 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
+  # training model under @to_static
+  to_static: False
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet50.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50.yaml
@@ -14,6 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
+  # training model under @to_static
+  to_static: False
 
 # model architecture
 Arch:

--- a/ppcls/engine/trainer.py
+++ b/ppcls/engine/trainer.py
@@ -34,6 +34,7 @@ from ppcls.utils.logger import init_logger
 from ppcls.utils.config import print_config
 from ppcls.data import build_dataloader
 from ppcls.arch import build_model
+from ppcls.arch import apply_to_static
 from ppcls.loss import build_loss
 from ppcls.metric import build_metrics
 from ppcls.optimizer import build_optimizer
@@ -73,6 +74,8 @@ class Trainer(object):
             self.is_rec = False
 
         self.model = build_model(self.config["Arch"])
+        # set @to_static for benchmark, skip this by default.
+        apply_to_static(self.config, self.model)
 
         if self.config["Global"]["pretrained_model"] is not None:
             load_dygraph_pretrain(self.model,


### PR DESCRIPTION
### What' New?

#### 1. 背景
目前 Benchamrk 平台上有静态图、动态图的训练数据监控，缺乏 动转静 @to_static 训练的性能监控，因此在 PaddleClas 动态图训练代码处进行了动转静支持。

#### 2. PR内容

选取 ResNet50、ResNet152、MobileNetV1、MobileNetV2为例，在 config.yaml 中添加 `support_to_static = True`（缺省则表示False）表示模型支持动转静。

同时支持训练时，通过 `-o to_static=True` 来开启动转静训练。

**支持单卡、8卡动转静训练**

> 注：若yaml配置中没有 `support_to_static` 字段，或执行时未指定 `-o to_static=True`，则训练行为与现有逻辑保持一致。

#### 3. 自测验证

基于 PaddleClas 首页的 QuickStart 教程中的 ResNet50_vd 自测没有问题，测试命令如下：（需在yaml添加support_to_static）
```bash
python3 tools/train.py -c ./ppcls/configs/ImageNet/ResNet/${config_file}
            -o Global.eval_during_train=False
            -o Global.to_static=True
            -o Global.epochs=${max_epoch}
            -o Global.print_batch_step=10
            -o DataLoader.Train.sampler.batch_size=${batch_size}
            -o DataLoader.Train.dataset.image_root=./dataset/imagenet100_data
            -o DataLoader.Train.dataset.cls_label_path=./dataset/imagenet100_data/${file_list}
            -o DataLoader.Train.loader.num_workers=8
```

#### 4. 模型影响面

**不会影响现有的模型**。

只有明确在yaml 文件中添加 `support_to_static: True` 才会支持 动转静训练。后续会推动模型陆续支持和打开此开关。