### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ujson
-opencv-python==4.1.2.30
+opencv-python==4.4.0.46
 pillow
 tqdm
 PyYAML


### PR DESCRIPTION
基于Windows、Linux平台，在Python3.6、3.7、3.8、3.9版本下验证过opencv-python==4.4.0.46可行。