### PR TITLE
fix fp16 inference

### DIFF
--- a/deploy/configs/inference_cls_ch4.yaml
+++ b/deploy/configs/inference_cls_ch4.yaml
@@ -22,7 +22,7 @@ PreProcess:
         mean: [0.485, 0.456, 0.406]
         std: [0.229, 0.224, 0.225]
         order: ''
-        channel_num: 3
+        channel_num: 4
     - ToCHWImage:
 PostProcess:
   main_indicator: Topk

--- a/ppcls/configs/ImageNet/ResNet/ResNet50_fp16.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50_fp16.yaml
@@ -28,6 +28,7 @@ Arch:
   name: ResNet50
   class_num: 1000
   input_image_channel: *image_channel
+  data_format: "NHWC"
  
 # loss function config for traing/eval process
 Loss:
@@ -41,7 +42,7 @@ Loss:
 Optimizer:
   name: Momentum
   momentum: 0.9
-  multi_precision: False # *use_pure_fp16
+  multi_precision: *use_pure_fp16
   lr:
     name: Piecewise
     learning_rate: 0.1


### PR DESCRIPTION
1. for fp16 model export, if training data format is set as "NHWC", you need to change it as "NCHW" (conv2d fusion just support NCHW for inference)

```
cfg="./ppcls/configs/ImageNet/ResNet/ResNet50_fp16.yaml"
pre="output/ResNet50/best_model"


python3.7 tools/export_model.py \
    -c ${cfg} \
    -o Global.pretrained_model="${pre}" \
    -o Arch.data_format="NCHW"
```

2. for fp16 model inference, if the image channel is set as 4 for training process, you need to use `configs/inference_cls_ch4.yaml` for the model inference.

```
python python/predict_cls.py -c configs/inference_cls_ch4.yaml
```