### PR TITLE
[Not Review] A demo of bf16 training for resnet50.

### DIFF
--- a/ppcls/configs/ImageNet/ResNet/ResNet50_bf16.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50_bf16.yaml
@@ -1,0 +1,145 @@
+# global configs
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: True
+  eval_interval: 1
+  epochs: 120
+  print_batch_step: 10
+  use_visualdl: False
+  # used for static mode and model export
+  image_channel: &image_channel 4
+  image_shape: [*image_channel, 224, 224]
+  save_inference_dir: ./inference
+  # training model under @to_static
+  to_static: False
+
+# mixed precision training
+AMP_BF16:
+  use_pure_bf16: False
+
+# model architecture
+Arch:
+  name: ResNet50
+  class_num: 1000
+  input_image_channel: *image_channel
+  data_format: "NHWC"
+ 
+# loss function config for traing/eval process
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+  Eval:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: Momentum
+  momentum: 0.9
+  multi_precision: False
+  lr:
+    name: Piecewise
+    learning_rate: 0.1
+    decay_epochs: [30, 60, 90]
+    values: [0.1, 0.01, 0.001, 0.0001]
+  regularizer:
+    name: 'L2'
+    coeff: 0.0001
+
+
+# data loader for train and eval
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: True
+            channel_first: False
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+            output_fp16: False
+            channel_num: *image_channel
+
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 32
+      drop_last: False
+      shuffle: True
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+
+  Eval:
+    dataset: 
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: True
+            channel_first: False
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+            output_fp16: False
+            channel_num: *image_channel
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 64
+      drop_last: False
+      shuffle: False
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+
+Infer:
+  infer_imgs: docs/images/whl/demo.jpg
+  batch_size: 10
+  transforms:
+    - DecodeImage:
+        to_rgb: True
+        channel_first: False
+    - ResizeImage:
+        resize_short: 256
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+        output_fp16: False
+        channel_num: *image_channel
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Train:
+    - TopkAcc:
+        topk: [1, 5]
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/static/program.py
+++ b/ppcls/static/program.py
@@ -221,6 +221,18 @@ def mixed_precision_optimizer(config, optimizer):
             use_pure_fp16=use_pure_fp16,
             use_fp16_guard=True)
 
+    if 'AMP_BF16' in config:
+        amp_cfg = config.AMP_BF16 if config.AMP_BF16 else dict()
+        use_pure_bf16 = amp_cfg.get('use_pure_bf16', False)
+        optimizer = paddle.static.amp.bf16.decorate_bf16(
+            optimizer,
+            amp_lists=paddle.static.amp.bf16.AutoMixedPrecisionListsBF16(
+                custom_bf16_list={
+                    'conv2d', 'batch_norm', 'elementwise_add', 'relu'
+                }),
+            use_bf16_guard=False,
+            use_pure_bf16=False)
+
     return optimizer
 
 


### PR DESCRIPTION
A100上使用bf16训练，依赖https://github.com/PaddlePaddle/Paddle/pull/34218 ，只有cast、conv2d、batch_norm、elementwise_add、relu五个算子支持bf16。

训练脚本如下：
```bash
export CUDA_VISIBLE_DEVICES="0"
export FLAGS_cudnn_exhaustive_search=1
export FLAGS_conv_workspace_size_limit=4000 #MB

batch_size=128
use_dali="True"
if [ ${use_dali} == "True" ]; then
  export FLAGS_fraction_of_gpu_memory_to_use=0.8
else
  export FLAGS_fraction_of_gpu_memory_to_use=0.98
fi

fuse_elewise_add_act_ops="False"
fuse_bn_act_ops="False"
fuse_bn_add_act_ops="False"
enable_addto="True"
if [ ${enable_addto} == "True" ]; then
  export FLAGS_max_inplace_grad_add=8
fi

precision="bf16"
config=ppcls/configs/ImageNet/ResNet/ResNet50_bf16.yaml
data_format="NHWC"
if [ ${data_format} == "NHWC" ]; then
  export FLAGS_cudnn_batchnorm_spatial_persistent=1
fi
amp_args="-o Arch.data_format=${data_format}
            -o Global.image_channel=4
            -o AMP_BF16.use_pure_bf16=False" 

python ${distribute_args} ppcls/static/train.py \
         -c ${config} \
         -o use_gpu=True \
         -o print_interval=10 \
         -o is_distributed=${is_distributed} \
         -o enable_addto=${enable_addto} \
         -o fuse_elewise_add_act_ops=${fuse_elewise_add_act_ops} \
         -o fuse_bn_act_ops=${fuse_bn_act_ops} \
         -o fuse_bn_add_act_ops=${fuse_bn_add_act_ops} \
         -o validate=False \
         -o epochs=1 \
         -o DataLoader.Train.sampler.batch_size=${batch_size} \
         -o DataLoader.Train.dataset.image_root=/data/ILSVRC2012 \
         -o DataLoader.Train.dataset.cls_label_path=/data/ILSVRC2012/train_list.txt \
         -o DataLoader.Train.loader.num_workers=8 \
         -o Global.save_interval=10000 \
         -o Global.eval_interval=10000 \
         -o Global.eval_during_train=False \
         -o Global.use_dali=${use_dali} ${amp_args}
```

训练log如下：（训练若干个batch后会挂掉，错误为`ExternalError: CUDNN error(8), CUDNN_STATUS_EXECUTION_FAILED.`，暂未解决。）
```
W1012 05:58:24.521028  5280 device_context.cc:447] Please NOTE: device: 0, GPU Compute Capability: 8.0, Driver API Version: 11.4, Runtime API Version: 11.4
W1012 05:58:24.521070  5280 device_context.cc:465] device: 0, cuDNN Version: 8.2.
W1012 05:58:30.401937  5280 build_strategy.cc:115] Currently, fuse_broadcast_ops only works under Reduce mode.
[2021/10/12 05:58:43] root INFO: epoch:0   train step:10   lr: 0.100000, loss:  8.1647 top1:  0.0000 top5:  0.0078 batch_cost: 0.07524 s, reader_cost: 0.00132 s, ips: 1701.18645 images/sec.
[2021/10/12 05:58:44] root INFO: epoch:0   train step:20   lr: 0.100000, loss:  8.0780 top1:  0.0000 top5:  0.0000 batch_cost: 0.07752 s, reader_cost: 0.00870 s, ips: 1651.14938 images/sec.
[2021/10/12 05:58:44] root INFO: epoch:0   train step:30   lr: 0.100000, loss:  7.2527 top1:  0.0000 top5:  0.0000 batch_cost: 0.07572 s, reader_cost: 0.00577 s, ips: 1690.37073 images/sec.
[2021/10/12 05:58:45] root INFO: epoch:0   train step:40   lr: 0.100000, loss:  6.8825 top1:  0.0000 top5:  0.0078 batch_cost: 0.07443 s, reader_cost: 0.00443 s, ips: 1719.69255 images/sec.
[2021/10/12 05:58:46] root INFO: epoch:0   train step:50   lr: 0.100000, loss:  7.0038 top1:  0.0000 top5:  0.0234 batch_cost: 0.07315 s, reader_cost: 0.00388 s, ips: 1749.87097 images/sec.
```