### PR TITLE
fix numpy array predict sample code

### DIFF
--- a/docs/zh_CN/whl.md
+++ b/docs/zh_CN/whl.md
@@ -181,6 +181,7 @@ import cv2
 from paddleclas import PaddleClas
 clas = PaddleClas(model_name='ResNet50')
 infer_imgs = cv2.imread("docs/images/whl/demo.jpg")
+infer_imgs = cv2.cvtColor(infer_imgs, cv2.COLOR_BGR2RGB)
 result=clas.predict(infer_imgs)
 print(next(result))
 ```


### PR DESCRIPTION
According to the source code and comments of function PaddleClas::predict, when predicting with numpy array, the channel order should be RGB.