### PR TITLE
[Benchmark] Change some settings for clas model`s trainning performance

### DIFF
--- a/ppcls/configs/ImageNet/HRNet/HRNet_W48_C.yaml
+++ b/ppcls/configs/ImageNet/HRNet/HRNet_W48_C.yaml
@@ -1,6 +1,3 @@
-# Conv config
-export FLAGS_cudnn_exhaustive_search=True
-
 # global configs
 Global:
   checkpoints: null

--- a/ppcls/configs/ImageNet/HRNet/HRNet_W48_C.yaml
+++ b/ppcls/configs/ImageNet/HRNet/HRNet_W48_C.yaml
@@ -1,3 +1,6 @@
+# Conv config
+export FLAGS_cudnn_exhaustive_search=True
+
 # global configs
 Global:
   checkpoints: null

--- a/ppcls/configs/ImageNet/MobileNetV1/MobileNetV1.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV1/MobileNetV1.yaml
@@ -71,7 +71,7 @@ DataLoader:
       drop_last: False
       shuffle: True
     loader:
-      num_workers: 4
+      num_workers: 8
       use_shared_memory: True
 
   Eval:

--- a/ppcls/configs/ImageNet/MobileNetV2/MobileNetV2.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV2/MobileNetV2.yaml
@@ -69,7 +69,7 @@ DataLoader:
       drop_last: False
       shuffle: True
     loader:
-      num_workers: 4
+      num_workers: 8
       use_shared_memory: True
 
   Eval:

--- a/ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_large_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_large_x1_0.yaml
@@ -70,7 +70,7 @@ DataLoader:
       drop_last: False
       shuffle: True
     loader:
-      num_workers: 4
+      num_workers: 8
       use_shared_memory: True
 
   Eval:

--- a/ppcls/configs/ImageNet/ShuffleNet/ShuffleNetV2_x1_0.yaml
+++ b/ppcls/configs/ImageNet/ShuffleNet/ShuffleNetV2_x1_0.yaml
@@ -68,7 +68,7 @@ DataLoader:
       drop_last: False
       shuffle: True
     loader:
-      num_workers: 4
+      num_workers: 8
       use_shared_memory: True
 
   Eval:


### PR DESCRIPTION
- As we found from model benchmark, once adjust the num_workers to 8 in MobileNetV1, MobileNetV2, MobileNetV3 and ShuffleNetV2 models, the trainning performance will acclerate, and HRNet model would benefit from openning the option of cudnn exhaustitve search.