### PR TITLE
[cherry-pick] fix repvgg

### DIFF
--- a/ppcls/arch/backbone/__init__.py
+++ b/ppcls/arch/backbone/__init__.py
@@ -61,6 +61,7 @@ from ppcls.arch.backbone.model_zoo.tnt import TNT_small
 from ppcls.arch.backbone.model_zoo.hardnet import HarDNet68, HarDNet85, HarDNet39_ds, HarDNet68_ds
 from ppcls.arch.backbone.model_zoo.cspnet import CSPDarkNet53
 from ppcls.arch.backbone.model_zoo.pvt_v2 import PVT_V2_B0, PVT_V2_B1, PVT_V2_B2_Linear, PVT_V2_B2, PVT_V2_B3, PVT_V2_B4, PVT_V2_B5
+from ppcls.arch.backbone.model_zoo.repvgg import RepVGG_A0, RepVGG_A1, RepVGG_A2, RepVGG_B0, RepVGG_B1, RepVGG_B2, RepVGG_B1g2, RepVGG_B1g4, RepVGG_B2g4, RepVGG_B3g4
 from ppcls.arch.backbone.variant_models.resnet_variant import ResNet50_last_stage_stride1
 from ppcls.arch.backbone.variant_models.vgg_variant import VGG19Sigmoid
 from ppcls.arch.backbone.variant_models.pp_lcnet_variant import PPLCNet_x2_5_Tanh

--- a/ppcls/arch/backbone/model_zoo/repvgg.py
+++ b/ppcls/arch/backbone/model_zoo/repvgg.py
@@ -92,6 +92,8 @@ class RepVGGBlock(nn.Layer):
                  groups=1,
                  padding_mode='zeros'):
         super(RepVGGBlock, self).__init__()
+        self.is_repped = False
+
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.kernel_size = kernel_size
@@ -127,6 +129,12 @@ class RepVGGBlock(nn.Layer):
             groups=groups)
 
     def forward(self, inputs):
+        if not self.training and not self.is_repped:
+            self.rep()
+            self.is_repped = True
+        if self.training and self.is_repped:
+            self.is_repped = False
+
         if not self.training:
             return self.nonlinearity(self.rbr_reparam(inputs))
 
@@ -137,7 +145,7 @@ class RepVGGBlock(nn.Layer):
         return self.nonlinearity(
             self.rbr_dense(inputs) + self.rbr_1x1(inputs) + id_out)
 
-    def eval(self):
+    def rep(self):
         if not hasattr(self, 'rbr_reparam'):
             self.rbr_reparam = nn.Conv2D(
                 in_channels=self.in_channels,
@@ -148,12 +156,9 @@ class RepVGGBlock(nn.Layer):
                 dilation=self.dilation,
                 groups=self.groups,
                 padding_mode=self.padding_mode)
-        self.training = False
         kernel, bias = self.get_equivalent_kernel_bias()
         self.rbr_reparam.weight.set_value(kernel)
         self.rbr_reparam.bias.set_value(bias)
-        for layer in self.sublayers():
-            layer.eval()
 
     def get_equivalent_kernel_bias(self):
         kernel3x3, bias3x3 = self._fuse_bn_tensor(self.rbr_dense)
@@ -247,12 +252,6 @@ class RepVGG(nn.Layer):
             self.in_planes = planes
             self.cur_layer_idx += 1
         return nn.Sequential(*blocks)
-
-    def eval(self):
-        self.training = False
-        for layer in self.sublayers():
-            layer.training = False
-            layer.eval()
 
     def forward(self, x):
         out = self.stage0(x)


### PR DESCRIPTION
The eval() overrided can't be called because model is a DataParallel object in distributed.