### PR TITLE
[TIPC-Benchmark]Support @to_static traing for Benchmark

### DIFF
--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -65,7 +65,20 @@ FILENAME=$new_filename
 # MODE must be one of ['benchmark_train']
 MODE=$2
 PARAMS=$3
-# bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train dynamic_bs8_null_DP_N1C1
+REST_ARGS=$4
+# bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train
+# bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train to_static
+# bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train dynamic_bs8_null_DP_N1C1 to_static
+
+# parse "to_static" options and modify trainer into "to_static_trainer"
+if [ $REST_ARGS = "to_static" ] || [ $PARAMS = "to_static" ] ;then
+   sed -i 's/trainer:norm_train/trainer:to_static_train/g' $FILENAME
+   # clear PARAM contents
+   if [ $PARAMS = "to_static" ] ;then
+    PARAMS=""
+   fi
+fi
+
 IFS=$'\n'
 # parser params from train_benchmark.txt
 sed -i 's/ -o DataLoader.Train.sampler.shuffle=False//g' $FILENAME

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -70,8 +70,10 @@ REST_ARGS=$4
 # bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train to_static
 # bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train dynamic_bs8_null_DP_N1C1 to_static
 
+to_static="d2sF"
 # parse "to_static" options and modify trainer into "to_static_trainer"
 if [ $REST_ARGS = "to_static" ] || [ $PARAMS = "to_static" ] ;then
+   to_static="d2sT"
    sed -i 's/trainer:norm_train/trainer:to_static_train/g' $FILENAME
    # clear PARAM contents
    if [ $PARAMS = "to_static" ] ;then
@@ -181,7 +183,7 @@ for batch_size in ${batch_size_list[*]}; do
             if [ ${#gpu_id} -le 1 ];then
                 log_path="$SAVE_LOG/profiling_log"
                 mkdir -p $log_path
-                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_profiling"
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}profiling"
                 func_sed_params "$FILENAME" "${line_gpuid}" "0"  # sed used gpu_id 
                 # set profile_option params
                 tmp=`sed -i "${line_profile}s/.*/${profile_option}/" "${FILENAME}"`
@@ -197,8 +199,8 @@ for batch_size in ${batch_size_list[*]}; do
                 speed_log_path="$SAVE_LOG/index"
                 mkdir -p $log_path
                 mkdir -p $speed_log_path
-                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_log"
-                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_speed"
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_log"
+                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_speed"
                 func_sed_params "$FILENAME" "${line_profile}" "null"  # sed profile_id as null
                 cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} benchmark_train > ${log_path}/${log_name} 2>&1 "
                 echo $cmd
@@ -232,8 +234,8 @@ for batch_size in ${batch_size_list[*]}; do
                 speed_log_path="$SAVE_LOG/index"
                 mkdir -p $log_path
                 mkdir -p $speed_log_path
-                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_log"
-                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_speed"
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_log"
+                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_speed"
                 func_sed_params "$FILENAME" "${line_gpuid}" "$gpu_id"  # sed used gpu_id 
                 func_sed_params "$FILENAME" "${line_profile}" "null"  # sed --profile_option as null
                 cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} benchmark_train > ${log_path}/${log_name} 2>&1 "

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -183,7 +183,7 @@ for batch_size in ${batch_size_list[*]}; do
             if [ ${#gpu_id} -le 1 ];then
                 log_path="$SAVE_LOG/profiling_log"
                 mkdir -p $log_path
-                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}profiling"
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}_profiling"
                 func_sed_params "$FILENAME" "${line_gpuid}" "0"  # sed used gpu_id 
                 # set profile_option params
                 tmp=`sed -i "${line_profile}s/.*/${profile_option}/" "${FILENAME}"`

--- a/test_tipc/config/MobileNetV1/MobileNetV1_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileNetV1/MobileNetV1.yaml
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params=========================== 

--- a/test_tipc/config/MobileNetV2/MobileNetV2_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileNetV2/MobileNetV2.yaml
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params=========================== 

--- a/test_tipc/config/ResNet/ResNet152_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet152_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/ResNet/ResNet152.yaml -o Glo
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params=========================== 

--- a/test_tipc/config/ResNet/ResNet50_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet50_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/ResNet/ResNet50.yaml -o Glob
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params=========================== 

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -40,8 +40,8 @@ fpgm_key=$(func_parser_key "${lines[17]}")
 fpgm_trainer=$(func_parser_value "${lines[17]}")
 distill_key=$(func_parser_key "${lines[18]}")
 distill_trainer=$(func_parser_value "${lines[18]}")
-trainer_key1=$(func_parser_key "${lines[19]}")
-trainer_value1=$(func_parser_value "${lines[19]}")
+to_static_key=$(func_parser_key "${lines[19]}")
+to_static_trainer=$(func_parser_value "${lines[19]}")
 trainer_key2=$(func_parser_key "${lines[20]}")
 trainer_value2=$(func_parser_value "${lines[20]}")
 
@@ -246,9 +246,12 @@ else
                 elif [ ${trainer} = "${distill_key}" ]; then
                     run_train=${distill_trainer}
                     run_export=${distill_export}
-                elif [ ${trainer} = ${trainer_key1} ]; then
-                    run_train=${trainer_value1}
-                    run_export=${export_value1}
+                # In case of @to_static, we re-used norm_traier,
+                # but append "-o Global.to_static=True" for config
+                # to trigger "apply_to_static" logic in 'engine.py'
+                elif [ ${trainer} = "${to_static_key}" ]; then
+                    run_train="${norm_trainer}  ${to_static_trainer}"
+                    run_export=${norm_export}
                 elif [[ ${trainer} = ${trainer_key2} ]]; then
                     run_train=${trainer_value2}
                     run_export=${export_value2}


### PR DESCRIPTION
## What's New?
此 PR 基于新Benchmark规范实现了 @to_static 动转静训练监控机制，在现有的功能上，为兼容性升级。

#### 1. 使用方式
在动态图训练的基础上，开启动转静训练的方法如下：

+ 配置参数名：`to_static`（不能拼写错误，大小写敏感）

```bash
# 方式一：对某个模型所有配置组合均开启动转静训练
bash test_tipc/benchmark_train.sh test_tipc/config/ResNet/ResNet50_train_infer_python.txt benchmark_train  to_static

# 方式二：对某个模型指定配置组合均开启动转静训练
bash test_tipc/benchmark_train.sh test_tipc/config/ResNet/ResNet50_train_infer_python.txt benchmark_train dynamic_bs8_fp32_DP_N1C2 to_static
``` 

### 2. 验证日志
此 PR 基于 RestNet和MobileNet 模型进行了单机单卡、多卡验证。

可以根据日志中的 `Successfully to apply @to_static with specs XX` 来判断动转静是否生效，日志如下：
```
[2022/03/14 08:13:16] root INFO: profiler_options : None
[2022/03/14 08:13:16] root INFO: train with paddle 0.0.0 and device Place(gpu:0)
W0314 08:13:24.551266 13696 gpu_context.cc:244] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 11.2, Runtime API Version: 11.2
W0314 08:13:24.556710 13696 gpu_context.cc:272] device: 0, cuDNN Version: 8.1.
[2022/03/14 08:13:28] root INFO: Successfully to apply @to_static with specs: [InputSpec(shape=(-1, 3, 224, 224), dtype=paddle.float32, name=None)]
[2022/03/14 08:13:28] root WARNING: The training strategy in config files provided by PaddleClas is based on 4 gpus. But the number of gpus is 1 in current training. Please modify the stategy (learning rate, batch size and so on) if use config files in PaddleClas to train.
[2022/03/14 08:13:32] root INFO: [Train][Epoch 1/1][Iter: 0/160146]lr: 0.10000, top1: 0.00000, top5: 0.00000, CELoss: 7.45196, loss: 7.45196, batch_cost: 3.92930s, reader_cost: 0.99335, ips: 2.03599 samples/s, eta: 7 days, 6:47:41
[2022/03/14 08:13:32] root INFO: [Train][Epoch 1/1][Iter: 1/160146]lr: 0.10000, top1: 0.00000, top5: 0.00000, CELoss: 21.29071, loss: 21.29071, batch_cost: 2.01570s, reader_cost: 0.49713, ips: 3.96885 samples/s, eta: 3 days, 17:40:03
```

### 3. 方案介绍
现有的 Benchmark 方案是通过执行`bash test_train_inference_python.sh`脚本实现的。

通过解析`test_tipc/config/test_xxx.txt` 中`trainer:norm_train`(第15行)来分发训练配置。此处我们扩展了第20行的配置，新增了动转静trainer：

+ `to_static_train:-o Global.to_static=True`

此处会复用`trainer:norm_train`的配置，在其后追加`-o Global.to_static=True` 来实现开启动转静训练，**以保证动转静训练和动态图训练的基本配置参数是对齐的。**