### PR TITLE
fix: fp32 eval by default when enable amp

### DIFF
--- a/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O2_ultra.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O2_ultra.yaml
@@ -24,6 +24,8 @@ AMP:
   use_dynamic_loss_scaling: True
   # O2: pure fp16
   level: O2
+  # only FP16 evaluation is supported when AMP O2 is enabled
+  use_fp16_test: True
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O2_ultra.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O2_ultra.yaml
@@ -24,8 +24,6 @@ AMP:
   use_dynamic_loss_scaling: True
   # O2: pure fp16
   level: O2
-  # only FP16 evaluation is supported when AMP O2 is enabled
-  use_fp16_test: True
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/SENet/SE_ResNeXt101_32x4d_amp_O2_ultra.yaml
+++ b/ppcls/configs/ImageNet/SENet/SE_ResNeXt101_32x4d_amp_O2_ultra.yaml
@@ -38,6 +38,8 @@ AMP:
     use_dynamic_loss_scaling: True
     # O2: pure fp16
     level: O2
+    # only FP16 evaluation is supported when AMP O2 is enabled
+    use_fp16_test: True
 
 Optimizer:
   name: Momentum

--- a/ppcls/configs/ImageNet/SENet/SE_ResNeXt101_32x4d_amp_O2_ultra.yaml
+++ b/ppcls/configs/ImageNet/SENet/SE_ResNeXt101_32x4d_amp_O2_ultra.yaml
@@ -34,12 +34,10 @@ Loss:
 
 # mixed precision training
 AMP:
-    scale_loss: 128.0
-    use_dynamic_loss_scaling: True
-    # O2: pure fp16
-    level: O2
-    # only FP16 evaluation is supported when AMP O2 is enabled
-    use_fp16_test: True
+  scale_loss: 128.0
+  use_dynamic_loss_scaling: True
+  # O2: pure fp16
+  level: O2
 
 Optimizer:
   name: Momentum

--- a/ppcls/engine/evaluation/classification.py
+++ b/ppcls/engine/evaluation/classification.py
@@ -53,7 +53,7 @@ def classification_eval(engine, epoch_id=0):
             ]
         time_info["reader_cost"].update(time.time() - tic)
         batch_size = batch[0].shape[0]
-        batch[0] = paddle.to_tensor(batch[0]).astype("float32")
+        batch[0] = paddle.to_tensor(batch[0])
         if not engine.config["Global"].get("use_multilabel", False):
             batch[1] = batch[1].reshape([-1, 1]).astype("int64")
 

--- a/ppcls/engine/evaluation/classification.py
+++ b/ppcls/engine/evaluation/classification.py
@@ -58,8 +58,15 @@ def classification_eval(engine, epoch_id=0):
             batch[1] = batch[1].reshape([-1, 1]).astype("int64")
 
         # image input
-        if engine.amp and engine.config["AMP"].get("use_fp16_test", False):
+        if engine.amp and (
+                engine.config['AMP'].get("level", "O1").upper() == "O2" or
+                engine.config["AMP"].get("use_fp16_test", False)):
             amp_level = engine.config['AMP'].get("level", "O1").upper()
+
+            if amp_level == "O2":
+                msg = "Only support FP16 evaluation when AMP O2 is enabled."
+                logger.warning(msg)
+
             with paddle.amp.auto_cast(
                     custom_black_list={
                         "flatten_contiguous_range", "greater_than"

--- a/ppcls/static/train.py
+++ b/ppcls/static/train.py
@@ -162,12 +162,21 @@ def main(args):
     init_model(global_config, train_prog, exe)
 
     if 'AMP' in config:
+        if config["AMP"].get("level", "O1").upper() == "O2":
+            use_fp16_test = True
+            msg = "Only support FP16 evaluation when AMP O2 is enabled."
+            logger.warning(msg)
+        elif "use_fp16_test" in config["AMP"]:
+            use_fp16_test = config["AMP"].get["use_fp16_test"]
+        else:
+            use_fp16_test = False
+
         optimizer.amp_init(
             device,
             scope=paddle.static.global_scope(),
             test_program=eval_prog
             if global_config["eval_during_train"] else None,
-            use_fp16_test=config["AMP"].get("use_fp16_test", False))
+            use_fp16_test=use_fp16_test)
 
     if not global_config.get("is_distributed", True):
         compiled_train_prog = program.compile(


### PR DESCRIPTION
If you want to fp16 eval when enable ampO2, please set Amp.use_fp16_test=True and set "output_fp16: True" in Dataloader.Eval.dataset.transform_ops.NormalizeImage.