### PR TITLE
fix FC initialization in reid-strong-baseline baseline config

### DIFF
--- a/ppcls/configs/Pedestrian/strong_baseline_baseline.yaml
+++ b/ppcls/configs/Pedestrian/strong_baseline_baseline.yaml
@@ -31,6 +31,14 @@ Arch:
     name: "FC"
     embedding_size: 2048
     class_num: 751
+    weight_attr:
+      initializer:
+        name: KaimingUniform
+        fan_in: 12288 # 6*embedding_size
+    bias_attr:
+      initializer:
+        name: KaimingUniform
+        fan_in: 12288 # 6*embedding_size
 
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/Pedestrian/strong_baseline_baseline.yaml
+++ b/ppcls/configs/Pedestrian/strong_baseline_baseline.yaml
@@ -60,7 +60,6 @@ Optimizer:
     name: Piecewise
     decay_epochs: [40, 70]
     values: [0.00035, 0.000035, 0.0000035]
-    warmup_epoch: 10
     by_epoch: True
     last_epoch: 0
   regularizer:


### PR DESCRIPTION
1. reid-strong-baseline baseline config中FC层的初始化使用了`KaimingUniform(fan_in)`，而该API在计算均匀分布的边界时与torch的FC层不一致，导致随机数的方差不同
具体地，torch的bound为sqrt(1/fan_in), [paddle](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/initializer/KaimingUniform_cn.html#kaiminguniform)为sqrt(6/fan_in)，因此将paddle的`fan_in`乘以6以抵消分子上的6，对齐分布的方差
验证代码：
```python
import torch
import paddle


inc, outc = 512, 2048
for i in range(20):
    tfc = torch.nn.Linear(inc, outc)
    pfc = paddle.nn.Linear(
        inc,
        outc,
        weight_attr=paddle.ParamAttr(initializer=paddle.nn.initializer.KaimingUniform(inc * 6)),
        bias_attr=paddle.ParamAttr(initializer=paddle.nn.initializer.KaimingUniform(inc * 6))
    )
    tw = tfc.weight
    pw = pfc.weight
    tb = tfc.bias
    pb = pfc.bias
    print(f"torch.weight均值：{tw.mean().item():.10f}\tpaddle.weight均值：{pw.mean().item():.10f}\ttorch.weight方差：{tw.std().item():.10f}\tpaddle.weight方差：{pw.std().item():.10f}")
    print(f"torch.bias均值：{tb.mean().item():.10f}\tpaddle.bias均值：{pb.mean().item():.10f}\ttorch.bias方差：{tb.std().item():.10f}\tpaddle.bias方差：{pb.std().item():.10f}")
    print("")
```
输出结果：
```
torch.weight均值：0.0000198224  paddle.weight均值：0.0000182140 torch.weight方差：0.0255044997  paddle.weight方差：0.0255032890
torch.bias均值：-0.0002675271   paddle.bias均值：-0.0007787503  torch.bias方差：0.0254521593    paddle.bias方差：0.0251168944

torch.weight均值：0.0000145027  paddle.weight均值：0.0000203150 torch.weight方差：0.0255180877  paddle.weight方差：0.0255340654
torch.bias均值：-0.0003460883   paddle.bias均值：0.0002332566   torch.bias方差：0.0255446099    paddle.bias方差：0.0258762762

torch.weight均值：0.0000002486  paddle.weight均值：-0.0000316723        torch.weight方差：0.0255173221  paddle.weight方差：0.0255042892
torch.bias均值：0.0004977946    paddle.bias均值：0.0006822916   torch.bias方差：0.0255978573    paddle.bias方差：0.0252706874

torch.weight均值：-0.0000144565 paddle.weight均值：0.0000321114 torch.weight方差：0.0255126581  paddle.weight方差：0.0255061518
torch.bias均值：0.0001768694    paddle.bias均值：-0.0002100967  torch.bias方差：0.0256604068    paddle.bias方差：0.0252163727

torch.weight均值：-0.0000231121 paddle.weight均值：-0.0000181104        torch.weight方差：0.0255240314  paddle.weight方差：0.0255150404
torch.bias均值：0.0000515928    paddle.bias均值：0.0006424117   torch.bias方差：0.0257746987    paddle.bias方差：0.0259242058

torch.weight均值：-0.0000090763 paddle.weight均值：0.0000014572 torch.weight方差：0.0255151484  paddle.weight方差：0.0254996344
torch.bias均值：0.0000988376    paddle.bias均值：-0.0003485709  torch.bias方差：0.0252861585    paddle.bias方差：0.0255923457

torch.weight均值：0.0000594570  paddle.weight均值：0.0000396802 torch.weight方差：0.0255324151  paddle.weight方差：0.0254966449
torch.bias均值：-0.0004696620   paddle.bias均值：0.0002510841   torch.bias方差：0.0257523935    paddle.bias方差：0.0253054500

torch.weight均值：0.0000004781  paddle.weight均值：0.0000092886 torch.weight方差：0.0255221389  paddle.weight方差：0.0255137477
torch.bias均值：-0.0005063954   paddle.bias均值：-0.0006366814  torch.bias方差：0.0253420901    paddle.bias方差：0.0253718719

torch.weight均值：-0.0000209725 paddle.weight均值：-0.0000155393        torch.weight方差：0.0255360324  paddle.weight方差：0.0255362280
torch.bias均值：0.0001430186    paddle.bias均值：-0.0007112597  torch.bias方差：0.0252480041    paddle.bias方差：0.0254995059

torch.weight均值：-0.0000196870 paddle.weight均值：-0.0000184484        torch.weight方差：0.0255216043  paddle.weight方差：0.0255146716
torch.bias均值：-0.0009489918   paddle.bias均值：-0.0012216562  torch.bias方差：0.0253764652    paddle.bias方差：0.0257107373
```
可以看到将`fan_in`乘以6后，方差大约在0.0255左右，与torch对齐

用上述对齐后的训练精度
| Market1501      | recall@1(%)      | mAP(%)      |
| ---------- | ---------- | ---------- |
| [pytorch](https://github.com/michuanhaohao/reid-strong-baseline#results-rank1map) | 87.7 | 74.0 |
| paddle | 87.70 | 74.03 |
