### PR TITLE
fix predict_det(#1896)

### DIFF
--- a/deploy/python/predict_det.py
+++ b/deploy/python/predict_det.py
@@ -125,16 +125,15 @@ class DetPredictor(Predictor):
         print("Inference: {} ms per batch image".format((t2 - t1) * 1000.0))
 
         # do not perform postprocess in benchmark mode
-        results = []
         if reduce(lambda x, y: x * y, np_boxes.shape) < 6:
             print('[WARNNING] No object detected.')
-            results = np.array([])
+            results = []
         else:
             results = np_boxes
 
-        results = self.parse_det_results(results,
-                                         self.config["Global"]["threshold"],
-                                         self.config["Global"]["labe_list"])
+            results = self.parse_det_results(results,
+                                             self.config["Global"]["threshold"],
+                                             self.config["Global"]["labe_list"])
         return results
 
 


### PR DESCRIPTION
解决predict_det.py未检测到目标时出错的问题，将self.parse_det_results处理放置到判断语句内，else时执行该操作，未检测到目标时不执行该操作，并且将results = []移到if条件下，因为results = np.array([])不能执行append操作，会在predict_system.py内报错，报错如下图

![image](https://user-images.githubusercontent.com/34644177/167418195-a23994af-d610-43a5-be19-d26a3b64010d.png)