### PR TITLE
fix interpolation to 'bilinear', adjust file structure and rename

### DIFF
--- a/ppcls/configs/reid/strong_baseline/baseline.yaml
+++ b/ppcls/configs/reid/strong_baseline/baseline.yaml
@@ -11,7 +11,7 @@ Global:
   print_batch_step: 20
   use_visualdl: False
   eval_mode: "retrieval"
-  retrieval_feature_from: "features" # 'backbone' or 'features'
+  retrieval_feature_from: "backbone" # 'backbone' or 'neck'
   # used for static mode and model export
   image_shape: [3, 256, 128]
   save_inference_dir: "./inference"
@@ -22,39 +22,29 @@ Arch:
   infer_output_key: "features"
   infer_add_softmax: False
   Backbone:
-    name: "ResNet50_last_stage_stride1"
+    name: "ResNet50"
     pretrained: True
     stem_act: null
   BackboneStopLayer:
     name: "flatten"
-  Neck:
-    name: BNNeck
-    num_features: &feat_dim 2048
-    weight_attr:
-      initializer:
-        name: Constant
-        value: 1.0
-    bias_attr:
-      initializer:
-        name: Constant
-        value: 0.0
-      learning_rate: 1.0e-20 # NOTE: Temporarily set lr small enough to freeze the bias to zero
   Head:
     name: "FC"
-    embedding_size: *feat_dim
+    embedding_size: 2048
     class_num: 751
     weight_attr:
       initializer:
-        name: Normal
-        std: 0.001
-    bias_attr: False
+        name: KaimingUniform
+        fan_in: 12288 # 6*embedding_size
+    bias_attr:
+      initializer:
+        name: KaimingUniform
+        fan_in: 12288 # 6*embedding_size
 
 # loss function config for traing/eval process
 Loss:
   Train:
     - CELoss:
         weight: 1.0
-        epsilon: 0.1
     - TripletLossV2:
         weight: 1.0
         margin: 0.3
@@ -68,10 +58,8 @@ Optimizer:
   name: Adam
   lr:
     name: Piecewise
-    decay_epochs: [30, 60]
+    decay_epochs: [40, 70]
     values: [0.00035, 0.000035, 0.0000035]
-    warmup_epoch: 10
-    warmup_start_lr: 0.0000035
     by_epoch: True
     last_epoch: 0
   regularizer:
@@ -90,6 +78,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - RandFlipImage:
               flip_code: 1
@@ -101,12 +90,6 @@ DataLoader:
           - Normalize:
               mean: [0.485, 0.456, 0.406]
               std: [0.229, 0.224, 0.225]
-          - RandomErasing:
-              EPSILON: 0.5
-              sl: 0.02
-              sh: 0.4
-              r1: 0.3
-              mean: [0.485, 0.456, 0.406]
     sampler:
         name: DistributedRandomIdentitySampler
         batch_size: 64
@@ -127,6 +110,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - ToTensor:
           - Normalize:
@@ -151,6 +135,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - ToTensor:
           - Normalize:

--- a/ppcls/configs/reid/strong_baseline/softmax_triplet.yaml
+++ b/ppcls/configs/reid/strong_baseline/softmax_triplet.yaml
@@ -42,7 +42,7 @@ Arch:
   Head:
     name: "FC"
     embedding_size: *feat_dim
-    class_num: &class_num 751
+    class_num: 751
     weight_attr:
       initializer:
         name: Normal
@@ -60,34 +60,23 @@ Loss:
         margin: 0.3
         normalize_feature: False
         feature_from: "backbone"
-    - CenterLoss:
-        weight: 0.0005
-        num_classes: *class_num
-        feat_dim: *feat_dim
-        feature_from: "backbone"
   Eval:
     - CELoss:
         weight: 1.0
 
 Optimizer:
-  - Adam:
-      scope: RecModel
-      lr:
-        name: Piecewise
-        decay_epochs: [30, 60]
-        values: [0.00035, 0.000035, 0.0000035]
-        warmup_epoch: 10
-        warmup_start_lr: 0.0000035
-        by_epoch: True
-        last_epoch: 0
-      regularizer:
-        name: 'L2'
-        coeff: 0.0005
-  - SGD:
-      scope: CenterLoss
-      lr:
-        name: Constant
-        learning_rate: 1000.0 # NOTE: set to ori_lr*(1/centerloss_weight) to avoid manually scaling centers' gradidents.
+  name: Adam
+  lr:
+    name: Piecewise
+    decay_epochs: [30, 60]
+    values: [0.00035, 0.000035, 0.0000035]
+    warmup_epoch: 10
+    warmup_start_lr: 0.0000035
+    by_epoch: True
+    last_epoch: 0
+  regularizer:
+    name: 'L2'
+    coeff: 0.0005
 
 # data loader for train and eval
 DataLoader:
@@ -101,6 +90,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - RandFlipImage:
               flip_code: 1
@@ -138,6 +128,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - ToTensor:
           - Normalize:
@@ -162,6 +153,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - ToTensor:
           - Normalize:

--- a/ppcls/configs/reid/strong_baseline/softmax_triplet_with_center.yaml
+++ b/ppcls/configs/reid/strong_baseline/softmax_triplet_with_center.yaml
@@ -11,7 +11,7 @@ Global:
   print_batch_step: 20
   use_visualdl: False
   eval_mode: "retrieval"
-  retrieval_feature_from: "backbone" # 'backbone' or 'neck'
+  retrieval_feature_from: "features" # 'backbone' or 'features'
   # used for static mode and model export
   image_shape: [3, 256, 128]
   save_inference_dir: "./inference"
@@ -22,49 +22,72 @@ Arch:
   infer_output_key: "features"
   infer_add_softmax: False
   Backbone:
-    name: "ResNet50"
+    name: "ResNet50_last_stage_stride1"
     pretrained: True
     stem_act: null
   BackboneStopLayer:
     name: "flatten"
-  Head:
-    name: "FC"
-    embedding_size: 2048
-    class_num: 751
+  Neck:
+    name: BNNeck
+    num_features: &feat_dim 2048
     weight_attr:
       initializer:
-        name: KaimingUniform
-        fan_in: 12288 # 6*embedding_size
+        name: Constant
+        value: 1.0
     bias_attr:
       initializer:
-        name: KaimingUniform
-        fan_in: 12288 # 6*embedding_size
+        name: Constant
+        value: 0.0
+      learning_rate: 1.0e-20 # NOTE: Temporarily set lr small enough to freeze the bias to zero
+  Head:
+    name: "FC"
+    embedding_size: *feat_dim
+    class_num: &class_num 751
+    weight_attr:
+      initializer:
+        name: Normal
+        std: 0.001
+    bias_attr: False
 
 # loss function config for traing/eval process
 Loss:
   Train:
     - CELoss:
         weight: 1.0
+        epsilon: 0.1
     - TripletLossV2:
         weight: 1.0
         margin: 0.3
         normalize_feature: False
+        feature_from: "backbone"
+    - CenterLoss:
+        weight: 0.0005
+        num_classes: *class_num
+        feat_dim: *feat_dim
         feature_from: "backbone"
   Eval:
     - CELoss:
         weight: 1.0
 
 Optimizer:
-  name: Adam
-  lr:
-    name: Piecewise
-    decay_epochs: [40, 70]
-    values: [0.00035, 0.000035, 0.0000035]
-    by_epoch: True
-    last_epoch: 0
-  regularizer:
-    name: 'L2'
-    coeff: 0.0005
+  - Adam:
+      scope: RecModel
+      lr:
+        name: Piecewise
+        decay_epochs: [30, 60]
+        values: [0.00035, 0.000035, 0.0000035]
+        warmup_epoch: 10
+        warmup_start_lr: 0.0000035
+        by_epoch: True
+        last_epoch: 0
+      regularizer:
+        name: 'L2'
+        coeff: 0.0005
+  - SGD:
+      scope: CenterLoss
+      lr:
+        name: Constant
+        learning_rate: 1000.0 # NOTE: set to ori_lr*(1/centerloss_weight) to avoid manually scaling centers' gradidents.
 
 # data loader for train and eval
 DataLoader:
@@ -78,6 +101,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - RandFlipImage:
               flip_code: 1
@@ -89,6 +113,12 @@ DataLoader:
           - Normalize:
               mean: [0.485, 0.456, 0.406]
               std: [0.229, 0.224, 0.225]
+          - RandomErasing:
+              EPSILON: 0.5
+              sl: 0.02
+              sh: 0.4
+              r1: 0.3
+              mean: [0.485, 0.456, 0.406]
     sampler:
         name: DistributedRandomIdentitySampler
         batch_size: 64
@@ -109,6 +139,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - ToTensor:
           - Normalize:
@@ -133,6 +164,7 @@ DataLoader:
           - ResizeImage:
               size: [128, 256]
               return_numpy: False
+              interpolation: 'bilinear'
               backend: "pil"
           - ToTensor:
           - Normalize:


### PR DESCRIPTION
1. 修复配置中`ResizeImage`未指定`interpolation`参数的bug
2. 调整文件结构&重命名