### PR TITLE
 fix ShuffleNetV2 config

### DIFF
--- a/ppcls/arch/backbone/model_zoo/shufflenet_v2.py
+++ b/ppcls/arch/backbone/model_zoo/shufflenet_v2.py
@@ -233,7 +233,7 @@ class ShuffleNet(Layer):
         elif scale == 1.5:
             stage_out_channels = [-1, 24, 176, 352, 704, 1024]
         elif scale == 2.0:
-            stage_out_channels = [-1, 24, 224, 488, 976, 2048]
+            stage_out_channels = [-1, 24, 244, 488, 976, 2048]
         else:
             raise NotImplementedError("This scale size:[" + str(scale) +
                                       "] is not implemented!")


### PR DESCRIPTION
 fix ShuffleNetV2 x2_0 stage_out_channels. [reference](https://github.com/pytorch/vision/blob/main/torchvision/models/shufflenetv2.py#L396)