### PR TITLE
fix: warn when topk parameter setting is wrong

### DIFF
--- a/ppcls/data/postprocess/topk.py
+++ b/ppcls/data/postprocess/topk.py
@@ -21,9 +21,9 @@ import paddle.nn.functional as F
 class Topk(object):
     def __init__(self, topk=1, class_id_map_file=None, delimiter=None):
         assert isinstance(topk, (int, ))
-        self.class_id_map = self.parse_class_id_map(class_id_map_file)
         self.topk = topk
         self.delimiter = delimiter if delimiter is not None else " "
+        self.class_id_map = self.parse_class_id_map(class_id_map_file)
 
     def parse_class_id_map(self, class_id_map_file):
         if class_id_map_file is None:

--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -177,7 +177,7 @@ class Engine(object):
                     self.eval_metric_func = None
             elif self.eval_mode == "retrieval":
                 if "Metric" in self.config and "Eval" in self.config["Metric"]:
-                    metric_config = metric_config["Metric"]["Eval"]
+                    metric_config = self.config["Metric"]["Eval"]
                 else:
                     metric_config = [{"name": "Recallk", "topk": (1, 5)}]
                 self.eval_metric_func = build_metrics(metric_config)

--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -159,10 +159,9 @@ class Engine(object):
                        ) and self.train_dataloader.collate_fn is not None:
                 for m_idx, m in enumerate(metric_config):
                     if "TopkAcc" in m:
-                        msg = f"'TopkAcc' metric can not be used when setting 'batch_transform_ops' in config. The 'TopkAcc' metric has been removed."
+                        msg = f"Unable to calculate accuracy when using \"batch_transform_ops\". The metric \"{m}\" has been removed."
                         logger.warning(msg)
-                        break
-                metric_config.pop(m_idx)
+                        metric_config.pop(m_idx)
             self.train_metric_func = build_metrics(metric_config)
         else:
             self.train_metric_func = None

--- a/ppcls/engine/evaluation/classification.py
+++ b/ppcls/engine/evaluation/classification.py
@@ -34,7 +34,6 @@ def classification_eval(engine, epoch_id=0):
     }
     print_batch_step = engine.config["Global"]["print_batch_step"]
 
-    metric_key = None
     tic = time.time()
     accum_samples = 0
     total_samples = len(

--- a/ppcls/metric/metrics.py
+++ b/ppcls/metric/metrics.py
@@ -40,7 +40,7 @@ class TopkAcc(AvgMetrics):
 
     def reset(self):
         self.avg_meters = {
-            "top{}".format(k): AverageMeter("top{}".format(k))
+            f"top{k}": AverageMeter(f"top{k}")
             for k in self.topk
         }
 
@@ -55,11 +55,14 @@ class TopkAcc(AvgMetrics):
             if output_dims < k:
                 msg = f"The output dims({output_dims}) is less than k({k}), and the argument {k} of Topk has been removed."
                 logger.warning(msg)
-                self.topk.pop(idx)
+                self.avg_meters.pop(f"top{k}")
                 continue
-            metric_dict["top{}".format(k)] = paddle.metric.accuracy(
-                x, label, k=k)
-            self.avg_meters["top{}".format(k)].update(metric_dict["top{}".format(k)], x.shape[0])
+            metric_dict[f"top{k}"] = paddle.metric.accuracy(x, label, k=k)
+            self.avg_meters[f"top{k}"].update(metric_dict[f"top{k}"],
+                                              x.shape[0])
+
+        self.topk = filter(lambda k: k <= output_dims, self.topk)
+
         return metric_dict
 
 


### PR DESCRIPTION
fix bugs:
1. warn when topk parameter setting is wrong;
2. there is a bug with poping TopkAcc when using batch_transform_ops;
3. class name can not output in infer.py.