### PR TITLE
Fix resume opt

### DIFF
--- a/ppcls/utils/save_load.py
+++ b/ppcls/utils/save_load.py
@@ -105,7 +105,7 @@ def init_model(config, net, optimizer=None, loss: paddle.nn.Layer=None):
         net.set_state_dict(para_dict)
         loss.set_state_dict(para_dict)
         for i in range(len(optimizer)):
-            optimizer[i].set_state_dict(opti_dict)
+            optimizer[i].set_state_dict(opti_dict[i])
         logger.info("Finish load checkpoints from {}".format(checkpoints))
         return metric_dict
 
@@ -117,7 +117,7 @@ def init_model(config, net, optimizer=None, loss: paddle.nn.Layer=None):
         else:  # common load
             load_dygraph_pretrain(net, path=pretrained_model)
             logger.info("Finish load pretrained model from {}".format(
-                    pretrained_model))
+                pretrained_model))
 
 
 def save_model(net,

--- a/ppcls/utils/save_load.py
+++ b/ppcls/utils/save_load.py
@@ -105,7 +105,8 @@ def init_model(config, net, optimizer=None, loss: paddle.nn.Layer=None):
         net.set_state_dict(para_dict)
         loss.set_state_dict(para_dict)
         for i in range(len(optimizer)):
-            optimizer[i].set_state_dict(opti_dict[i])
+            optimizer[i].set_state_dict(opti_dict[i] if isinstance(
+                opti_dict, list) else opti_dict)
         logger.info("Finish load checkpoints from {}".format(checkpoints))
         return metric_dict
 


### PR DESCRIPTION
1. 修复save_load函数在载入时不兼容类型为Dict的optimizer_dict的情况
  修复前：

    ```
    File "/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/optimizer/optimizer.py", line 302, in set_state_dict
        self._learning_rate.set_dict(state_dict["LR_Scheduler"])
    TypeError: list indices must be integers or slices, not str
    ```

    修复后：
    ```
    Finish load checkpoints from ./output/RecModel/latest
    ```