### PR TITLE
remove gpu infer path in train_fleet_config

### DIFF
--- a/test_tipc/config/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
@@ -20,7 +20,7 @@ distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5.yaml
 null:null
 ##
@@ -38,7 +38,7 @@ infer_model:../inference/
 infer_export:True
 infer_quant:Fasle
 inference:python/predict_rec.py -c configs/inference_rec.yaml
--o Global.use_gpu:True|False
+-o Global.use_gpu:False
 -o Global.enable_mkldnn:True|False
 -o Global.cpu_num_threads:1|6
 -o Global.batch_size:1|16

--- a/test_tipc/config/PPHGNet/PPHGNet_small_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/PPHGNet/PPHGNet_small_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
@@ -20,7 +20,7 @@ distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPHGNet/PPHGNet_small.yaml
 null:null
 ##
@@ -38,7 +38,7 @@ infer_model:../inference/
 infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=236
--o Global.use_gpu:True|False
+-o Global.use_gpu:False
 -o Global.enable_mkldnn:True|False
 -o Global.cpu_num_threads:1|6
 -o Global.batch_size:1|16

--- a/test_tipc/config/PPLCNet/MobileNetV3_large_x1_0_lite_arm_cpu_cpp.txt
+++ b/test_tipc/config/PPLCNet/MobileNetV3_large_x1_0_lite_arm_cpu_cpp.txt
@@ -1,8 +1,0 @@
-runtime_device:arm_cpu
-lite_arm_work_path:/data/local/tmp/arm_cpu/
-lite_arm_so_path:inference_lite_lib.android.armv8/cxx/lib/libpaddle_light_api_shared.so
-clas_model_file:MobileNetV3_large_x1_0
-inference_cmd:clas_system config.txt tabby_cat.jpg
---num_threads_list:1
---batch_size_list:1
---precision_list:FP32

--- a/test_tipc/config/PPLCNet/PPLCNet_x1_0_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x1_0_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
@@ -20,7 +20,7 @@ distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x1_0.yaml
 null:null
 ##
@@ -38,7 +38,7 @@ infer_model:../inference/
 infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
--o Global.use_gpu:True|False
+-o Global.use_gpu:False
 -o Global.enable_mkldnn:True|False
 -o Global.cpu_num_threads:1|6
 -o Global.batch_size:1|16

--- a/test_tipc/config/PPLCNetV2/PPLCNetV2_base_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/PPLCNetV2/PPLCNetV2_base_train_linux_gpu_fleet_normal_infer_python_linux_gpu_cpu.txt
@@ -38,7 +38,7 @@ infer_model:../inference/
 infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
--o Global.use_gpu:True|False
+-o Global.use_gpu:False
 -o Global.enable_mkldnn:True|False
 -o Global.cpu_num_threads:1|6
 -o Global.batch_size:1|16

--- a/test_tipc/docs/test_serving_infer_cpp.md
+++ b/test_tipc/docs/test_serving_infer_cpp.md
@@ -1,30 +1,30 @@
-# Linux GPU/CPU PYTHON 服务化部署测试
+# Linux GPU/CPU C++ 服务化部署测试
 
-Linux GPU/CPU  PYTHON 服务化部署测试的主程序为`test_serving_infer_cpp.sh`，可以测试基于Python的模型服务化部署功能。
+Linux GPU/CPU C++ 服务化部署测试的主程序为`test_serving_infer_cpp.sh`，可以测试基于C++的模型服务化部署功能。
 
 
 ## 1. 测试结论汇总
 
 - 推理相关：
 
-| 算法名称   | 模型名称  | device_CPU          | device_GPU |
-|  :----:   |  :----: |   :----:            |  :----:  |
-|  MobileNetV3   |  MobileNetV3_large_x1_0 |  支持 | 支持 |
-|  PP-ShiTu   |  PPShiTu_general_rec、PPShiTu_mainbody_det |  支持 | 支持 |
-|  PPHGNet   |  PPHGNet_small |  支持 | 支持 |
-|  PPHGNet   |  PPHGNet_tiny |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_25 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_35 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_5 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_75 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x1_0 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x1_5 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x2_0 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x2_5 |  支持 | 支持 |
-|  PPLCNetV2   |  PPLCNetV2_base |  支持 | 支持 |
-|  ResNet   |  ResNet50 |  支持 | 支持 |
-|  ResNet   |  ResNet50_vd |  支持 | 支持 |
-|  SwinTransformer   |  SwinTransformer_tiny_patch4_window7_224 |  支持 | 支持 |
+|    算法名称     |                 模型名称                  | device_CPU | device_GPU |
+| :-------------: | :---------------------------------------: | :--------: | :--------: |
+|   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
+|    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
+|     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
+|     PPHGNet     |               PPHGNet_tiny                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_25               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_35               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_5                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_75               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x1_0                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x1_5                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x2_0                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x2_5                |    支持    |    支持    |
+|    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
+|     ResNet      |                 ResNet50                  |    支持    |    支持    |
+|     ResNet      |                ResNet50_vd                |    支持    |    支持    |
+| SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 
 ## 2. 测试流程

--- a/test_tipc/docs/test_serving_infer_python.md
+++ b/test_tipc/docs/test_serving_infer_python.md
@@ -1,30 +1,30 @@
 # Linux GPU/CPU PYTHON 服务化部署测试
 
-Linux GPU/CPU  PYTHON 服务化部署测试的主程序为`test_serving_infer_python.sh`，可以测试基于Python的模型服务化部署功能。
+Linux GPU/CPU PYTHON 服务化部署测试的主程序为`test_serving_infer_python.sh`，可以测试基于Python的模型服务化部署功能。
 
 
 ## 1. 测试结论汇总
 
 - 推理相关：
 
-| 算法名称   | 模型名称  | device_CPU          | device_GPU |
-|  :----:   |  :----: |   :----:            |  :----:  |
-|  MobileNetV3   |  MobileNetV3_large_x1_0 |  支持 | 支持 |
-|  PP-ShiTu   |  PPShiTu_general_rec、PPShiTu_mainbody_det |  支持 | 支持 |
-|  PPHGNet   |  PPHGNet_small |  支持 | 支持 |
-|  PPHGNet   |  PPHGNet_tiny |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_25 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_35 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_5 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_75 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x1_0 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x1_5 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x2_0 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x2_5 |  支持 | 支持 |
-|  PPLCNetV2   |  PPLCNetV2_base |  支持 | 支持 |
-|  ResNet   |  ResNet50 |  支持 | 支持 |
-|  ResNet   |  ResNet50_vd |  支持 | 支持 |
-|  SwinTransformer   |  SwinTransformer_tiny_patch4_window7_224 |  支持 | 支持 |
+|    算法名称     |                 模型名称                  | device_CPU | device_GPU |
+| :-------------: | :---------------------------------------: | :--------: | :--------: |
+|   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
+|    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
+|     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
+|     PPHGNet     |               PPHGNet_tiny                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_25               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_35               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_5                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_75               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x1_0                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x1_5                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x2_0                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x2_5                |    支持    |    支持    |
+|    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
+|     ResNet      |                 ResNet50                  |    支持    |    支持    |
+|     ResNet      |                ResNet50_vd                |    支持    |    支持    |
+| SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 
 ## 2. 测试流程

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -205,7 +205,7 @@ if [[ ${MODE} = "serving_infer" ]]; then
     python_name=$(func_parser_value "${lines[2]}")
     if [[ ${FILENAME} =~ "cpp" ]]; then
         pushd ./deploy/paddleserving
-        bash build_server.sh ${python_name}
+        source build_server.sh ${python_name}
         popd
     else
         ${python_name} -m pip install install paddle-serving-server-gpu==0.9.0.post101 -i https://pypi.tuna.tsinghua.edu.cn/simple


### PR DESCRIPTION
1. 去掉 train_fleet 链条中 gpu infer的path，只保留 cpu infer
2. 删除PPLCNet文件夹下多余的 MobileNetV3_large_x1_0_lite_arm_cpu_cpp.txt 文件
3. prepare.sh编译serving从bash改为source
4. cpp serving文档部分文字错误修正