### PR TITLE
Add kl quant chain

### DIFF
--- a/deploy/slim/quant_post_static.py
+++ b/deploy/slim/quant_post_static.py
@@ -43,6 +43,7 @@ def main():
                                       'inference.pdiparams'))
     config["DataLoader"]["Eval"]["sampler"]["batch_size"] = 1
     config["DataLoader"]["Eval"]["loader"]["num_workers"] = 0
+
     init_logger()
     device = paddle.set_device("cpu")
     train_dataloader = build_dataloader(config["DataLoader"], "Eval", device,
@@ -67,6 +68,7 @@ def main():
         quantize_model_path=os.path.join(
             config["Global"]["save_inference_dir"], "quant_post_static_model"),
         sample_generator=sample_generator(train_dataloader),
+        batch_size=config["DataLoader"]["Eval"]["sampler"]["batch_size"],
         batch_nums=10)
 
 

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
@@ -1,5 +1,5 @@
 ===========================cpp_infer_params===========================
-model_name:MobileNetV3_large_x1_0_kl_quant
+model_name:MobileNetV3_large_x1_0_KL
 cpp_infer_type:cls
 cls_inference_model_dir:./MobileNetV3_large_x1_0_kl_quant_infer/
 det_inference_model_dir:

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
@@ -1,5 +1,5 @@
 ===========================cpp_infer_params===========================
-model_name:MobileNetV3_large_x1_0_kl
+model_name:MobileNetV3_large_x1_0_kl_quant
 cpp_infer_type:cls
 cls_inference_model_dir:./MobileNetV3_large_x1_0_kl_quant_infer/
 det_inference_model_dir:

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
@@ -1,0 +1,18 @@
+===========================cpp_infer_params===========================
+model_name:MobileNetV3_large_x1_0_kl
+cpp_infer_type:cls
+cls_inference_model_dir:./MobileNetV3_large_x1_0_kl_quant_infer/
+det_inference_model_dir:
+cls_inference_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/MobileNetV3_large_x1_0_kl_quant_infer.tar
+det_inference_url:
+infer_quant:False
+inference_cmd:./deploy/cpp/build/clas_system -c inference_cls.yaml
+use_gpu:True|False
+enable_mkldnn:False
+cpu_threads:1
+batch_size:1
+use_tensorrt:False
+precision:fp32
+image_dir:./dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+benchmark:False
+generate_yaml_cmd:python3.7 test_tipc/generate_cpp_yaml.py

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
@@ -1,0 +1,14 @@
+===========================serving_params===========================
+model_name:MobileNetV3_large_x1_0_kl_quant
+python:python3.7
+inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/MobileNetV3_large_x1_0_kl_quant_infer.tar
+trans_model:-m paddle_serving_client.convert
+--dirname:./deploy/paddleserving/MobileNetV3_large_x1_0_kl_quant_infer/
+--model_filename:inference.pdmodel
+--params_filename:inference.pdiparams
+--serving_server:./deploy/paddleserving/MobileNetV3_large_x1_0_kl_quant_serving/
+--serving_client:./deploy/paddleserving/MobileNetV3_large_x1_0_kl_quant_client/
+serving_dir:./deploy/paddleserving
+web_service:null
+--use_gpu:0|null
+pipline:test_cpp_serving_client.py

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
@@ -1,5 +1,5 @@
 ===========================serving_params===========================
-model_name:MobileNetV3_large_x1_0_kl_quant
+model_name:MobileNetV3_large_x1_0_KL
 python:python3.7
 inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/MobileNetV3_large_x1_0_kl_quant_infer.tar
 trans_model:-m paddle_serving_client.convert

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
@@ -1,5 +1,5 @@
 ===========================serving_params===========================
-model_name:MobileNetV3_large_x1_0_kl_quant
+model_name:MobileNetV3_large_x1_0_KL
 python:python3.7
 inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileNetV3_large_x1_0_infer.tar
 trans_model:-m paddle_serving_client.convert

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
@@ -1,0 +1,14 @@
+===========================serving_params===========================
+model_name:MobileNetV3_large_x1_0_kl_quant
+python:python3.7
+inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileNetV3_large_x1_0_infer.tar
+trans_model:-m paddle_serving_client.convert
+--dirname:./deploy/paddleserving/MobileNetV3_large_x1_0_kl_quant_infer/
+--model_filename:inference.pdmodel
+--params_filename:inference.pdiparams
+--serving_server:./deploy/paddleserving/MobileNetV3_large_x1_0_kl_quant_serving/
+--serving_client:./deploy/paddleserving/MobileNetV3_large_x1_0_kl_quant_client/
+serving_dir:./deploy/paddleserving
+web_service:classification_web_service.py
+--use_gpu:0|null
+pipline:pipeline_http_client.py

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
@@ -1,7 +1,7 @@
 ===========================serving_params===========================
 model_name:MobileNetV3_large_x1_0_KL
 python:python3.7
-inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileNetV3_large_x1_0_infer.tar
+inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/MobileNetV3_large_x1_0_kl_quant_infer.tar
 trans_model:-m paddle_serving_client.convert
 --dirname:./deploy/paddleserving/MobileNetV3_large_x1_0_kl_quant_infer/
 --model_filename:inference.pdmodel

--- a/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
@@ -1,0 +1,18 @@
+===========================cpp_infer_params===========================
+model_name:ResNet50_vd_kl_quant
+cpp_infer_type:cls
+cls_inference_model_dir:./ResNet50_vd_kl_quant_infer/
+det_inference_model_dir:
+cls_inference_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/ResNet50_vd_kl_quant_infer.tar
+det_inference_url:
+infer_quant:False
+inference_cmd:./deploy/cpp/build/clas_system -c inference_cls.yaml
+use_gpu:True|False
+enable_mkldnn:False
+cpu_threads:1
+batch_size:1
+use_tensorrt:False
+precision:fp32
+image_dir:./dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+benchmark:False
+generate_yaml_cmd:python3.7 test_tipc/generate_cpp_yaml.py

--- a/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_infer_cpp_linux_gpu_cpu.txt
@@ -1,5 +1,5 @@
 ===========================cpp_infer_params===========================
-model_name:ResNet50_vd_kl_quant
+model_name:ResNet50_vd_KL
 cpp_infer_type:cls
 cls_inference_model_dir:./ResNet50_vd_kl_quant_infer/
 det_inference_model_dir:

--- a/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
@@ -1,5 +1,5 @@
 ===========================serving_params===========================
-model_name:ResNet50_vd_kl_quant
+model_name:ResNet50_vd_KL
 python:python3.7
 inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/ResNet50_vd_kl_quant_infer.tar
 trans_model:-m paddle_serving_client.convert

--- a/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_cpp_linux_gpu_cpu.txt
@@ -1,0 +1,14 @@
+===========================serving_params===========================
+model_name:ResNet50_vd_kl_quant
+python:python3.7
+inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/ResNet50_vd_kl_quant_infer.tar
+trans_model:-m paddle_serving_client.convert
+--dirname:./deploy/paddleserving/ResNet50_vd_kl_quant_infer/
+--model_filename:inference.pdmodel
+--params_filename:inference.pdiparams
+--serving_server:./deploy/paddleserving/ResNet50_vd_kl_quant_serving/
+--serving_client:./deploy/paddleserving/ResNet50_vd_kl_quant_client/
+serving_dir:./deploy/paddleserving
+web_service:null
+--use_gpu:0|null
+pipline:test_cpp_serving_client.py

--- a/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
@@ -1,0 +1,14 @@
+===========================serving_params===========================
+model_name:ResNet50_vd_kl_quant
+python:python3.7
+inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/ResNet50_vd_kl_quant_infer.tar
+trans_model:-m paddle_serving_client.convert
+--dirname:./deploy/paddleserving/ResNet50_vd_kl_quant_infer/
+--model_filename:inference.pdmodel
+--params_filename:inference.pdiparams
+--serving_server:./deploy/paddleserving/ResNet50_vd_kl_quant_serving/
+--serving_client:./deploy/paddleserving/ResNet50_vd_kl_quant_client/
+serving_dir:./deploy/paddleserving
+web_service:classification_web_service.py
+--use_gpu:0|null
+pipline:pipeline_http_client.py

--- a/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd-KL_linux_gpu_normal_normal_serving_python_linux_gpu_cpu.txt
@@ -1,5 +1,5 @@
 ===========================serving_params===========================
-model_name:ResNet50_vd_kl_quant
+model_name:ResNet50_vd_KL
 python:python3.7
 inference_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/slim_model/ResNet50_vd_kl_quant_infer.tar
 trans_model:-m paddle_serving_client.convert

--- a/test_tipc/docs/test_inference_cpp.md
+++ b/test_tipc/docs/test_inference_cpp.md
@@ -6,25 +6,27 @@ Linux GPU/CPU C++ 推理功能测试的主程序为`test_inference_cpp.sh`，可
 
 - 推理相关：
 
-| 算法名称   | 模型名称  | device_CPU          | device_GPU |
-|  :----:   |  :----: |   :----:            |  :----:  |
-|  MobileNetV3   |  MobileNetV3_large_x1_0 |  支持 | 支持 |
-|  PP-ShiTu   |  PPShiTu_general_rec、PPShiTu_mainbody_det |  支持 | 支持 |
-|  PP-ShiTu   |  PPShiTu_mainbody_det |  支持 | 支持 |
-|  PPHGNet   |  PPHGNet_small |  支持 | 支持 |
-|  PPHGNet   |  PPHGNet_tiny |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_25 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_35 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_5 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x0_75 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x1_0 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x1_5 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x2_0 |  支持 | 支持 |
-|  PPLCNet   |  PPLCNet_x2_5 |  支持 | 支持 |
-|  PPLCNetV2   |  PPLCNetV2_base |  支持 | 支持 |
-|  ResNet   |  ResNet50 |  支持 | 支持 |
-|  ResNet   |  ResNet50_vd |  支持 | 支持 |
-|  SwinTransformer   |  SwinTransformer_tiny_patch4_window7_224 |  支持 | 支持 |
+|    算法名称     |                 模型名称                  | device_CPU | device_GPU |
+| :-------------: | :---------------------------------------: | :--------: | :--------: |
+|   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
+|   MobileNetV3   |         MobileNetV3_large_x1_0-KL         |    支持    |    支持    |
+|    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
+|    PP-ShiTu     |           PPShiTu_mainbody_det            |    支持    |    支持    |
+|     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
+|     PPHGNet     |               PPHGNet_tiny                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_25               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_35               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_5                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x0_75               |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x1_0                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x1_5                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x2_0                |    支持    |    支持    |
+|     PPLCNet     |               PPLCNet_x2_5                |    支持    |    支持    |
+|    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
+|     ResNet      |                 ResNet50                  |    支持    |    支持    |
+|     ResNet      |                ResNet50_vd                |    支持    |    支持    |
+|     ResNet      |              ResNet50_vd-KL               |    支持    |    支持    |
+| SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 ## 2. 测试流程(以**ResNet50**为例)
 

--- a/test_tipc/docs/test_inference_cpp.md
+++ b/test_tipc/docs/test_inference_cpp.md
@@ -167,11 +167,11 @@ build/paddle_inference_install_dir/
 
 * [Paddle预测库官网](https://paddleinference.paddlepaddle.org.cn/user_guides/download_lib.html)上提供了不同cuda版本的Linux预测库，可以在官网查看并选择合适的预测库版本。
 
-  以`manylinux_cuda11.1_cudnn8.1_avx_mkl_trt7_gcc8.2`版本为例，使用下述命令下载并解压：
+  以`manylinux_cuda10.1_cudnn7.6_avx_mkl_trt6_gcc8.2`版本为例，使用下述命令下载并解压：
 
 
 ```shell
-wget https://paddle-inference-lib.bj.bcebos.com/2.2.2/cxx_c/Linux/GPU/x86-64_gcc8.2_avx_mkl_cuda11.1_cudnn8.1.1_trt7.2.3.4/paddle_inference.tgz
+wget https://paddle-inference-lib.bj.bcebos.com/2.2.2/cxx_c/Linux/GPU/x86-64_gcc8.2_avx_mkl_cuda10.1_cudnn7.6.5_trt6.0.1.5/paddle_inference.tgz
 
 tar -xvf paddle_inference.tgz
 ```

--- a/test_tipc/docs/test_inference_cpp.md
+++ b/test_tipc/docs/test_inference_cpp.md
@@ -9,7 +9,7 @@ Linux GPU/CPU C++ 推理功能测试的主程序为`test_inference_cpp.sh`，可
 |    算法名称     |                 模型名称                  | device_CPU | device_GPU |
 | :-------------: | :---------------------------------------: | :--------: | :--------: |
 |   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
-|   MobileNetV3   |         MobileNetV3_large_x1_0-KL         |    支持    |    支持    |
+|   MobileNetV3   |         MobileNetV3_large_x1_0_KL         |    支持    |    支持    |
 |    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
 |    PP-ShiTu     |           PPShiTu_mainbody_det            |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
@@ -25,7 +25,7 @@ Linux GPU/CPU C++ 推理功能测试的主程序为`test_inference_cpp.sh`，可
 |    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
 |     ResNet      |                 ResNet50                  |    支持    |    支持    |
 |     ResNet      |                ResNet50_vd                |    支持    |    支持    |
-|     ResNet      |              ResNet50_vd-KL               |    支持    |    支持    |
+|     ResNet      |              ResNet50_vd_KL               |    支持    |    支持    |
 | SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 ## 2. 测试流程(以**ResNet50**为例)

--- a/test_tipc/docs/test_serving_infer_cpp.md
+++ b/test_tipc/docs/test_serving_infer_cpp.md
@@ -10,7 +10,7 @@ Linux GPU/CPU C++ 服务化部署测试的主程序为`test_serving_infer_cpp.sh
 |    算法名称     |                 模型名称                  | device_CPU | device_GPU |
 | :-------------: | :---------------------------------------: | :--------: | :--------: |
 |   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
-|   MobileNetV3   |         MobileNetV3_large_x1_0-KL         |    支持    |    支持    |
+|   MobileNetV3   |         MobileNetV3_large_x1_0_KL         |    支持    |    支持    |
 |    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_tiny                |    支持    |    支持    |
@@ -25,7 +25,7 @@ Linux GPU/CPU C++ 服务化部署测试的主程序为`test_serving_infer_cpp.sh
 |    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
 |     ResNet      |                 ResNet50                  |    支持    |    支持    |
 |     ResNet      |                ResNet50_vd                |    支持    |    支持    |
-|     ResNet      |              ResNet50_vd-KL               |    支持    |    支持    |
+|     ResNet      |              ResNet50_vd_KL               |    支持    |    支持    |
 | SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 

--- a/test_tipc/docs/test_serving_infer_cpp.md
+++ b/test_tipc/docs/test_serving_infer_cpp.md
@@ -10,6 +10,7 @@ Linux GPU/CPU C++ 服务化部署测试的主程序为`test_serving_infer_cpp.sh
 |    算法名称     |                 模型名称                  | device_CPU | device_GPU |
 | :-------------: | :---------------------------------------: | :--------: | :--------: |
 |   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
+|   MobileNetV3   |         MobileNetV3_large_x1_0-KL         |    支持    |    支持    |
 |    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_tiny                |    支持    |    支持    |
@@ -24,6 +25,7 @@ Linux GPU/CPU C++ 服务化部署测试的主程序为`test_serving_infer_cpp.sh
 |    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
 |     ResNet      |                 ResNet50                  |    支持    |    支持    |
 |     ResNet      |                ResNet50_vd                |    支持    |    支持    |
+|     ResNet      |              ResNet50_vd-KL               |    支持    |    支持    |
 | SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 

--- a/test_tipc/docs/test_serving_infer_python.md
+++ b/test_tipc/docs/test_serving_infer_python.md
@@ -10,6 +10,7 @@ Linux GPU/CPU PYTHON 服务化部署测试的主程序为`test_serving_infer_pyt
 |    算法名称     |                 模型名称                  | device_CPU | device_GPU |
 | :-------------: | :---------------------------------------: | :--------: | :--------: |
 |   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
+|   MobileNetV3   |         MobileNetV3_large_x1_0-KL         |    支持    |    支持    |
 |    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_tiny                |    支持    |    支持    |
@@ -24,6 +25,7 @@ Linux GPU/CPU PYTHON 服务化部署测试的主程序为`test_serving_infer_pyt
 |    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
 |     ResNet      |                 ResNet50                  |    支持    |    支持    |
 |     ResNet      |                ResNet50_vd                |    支持    |    支持    |
+|     ResNet      |              ResNet50_vd-KL               |    支持    |    支持    |
 | SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 

--- a/test_tipc/docs/test_serving_infer_python.md
+++ b/test_tipc/docs/test_serving_infer_python.md
@@ -10,7 +10,7 @@ Linux GPU/CPU PYTHON 服务化部署测试的主程序为`test_serving_infer_pyt
 |    算法名称     |                 模型名称                  | device_CPU | device_GPU |
 | :-------------: | :---------------------------------------: | :--------: | :--------: |
 |   MobileNetV3   |          MobileNetV3_large_x1_0           |    支持    |    支持    |
-|   MobileNetV3   |         MobileNetV3_large_x1_0-KL         |    支持    |    支持    |
+|   MobileNetV3   |         MobileNetV3_large_x1_0_KL         |    支持    |    支持    |
 |    PP-ShiTu     | PPShiTu_general_rec、PPShiTu_mainbody_det |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_small               |    支持    |    支持    |
 |     PPHGNet     |               PPHGNet_tiny                |    支持    |    支持    |
@@ -25,7 +25,7 @@ Linux GPU/CPU PYTHON 服务化部署测试的主程序为`test_serving_infer_pyt
 |    PPLCNetV2    |              PPLCNetV2_base               |    支持    |    支持    |
 |     ResNet      |                 ResNet50                  |    支持    |    支持    |
 |     ResNet      |                ResNet50_vd                |    支持    |    支持    |
-|     ResNet      |              ResNet50_vd-KL               |    支持    |    支持    |
+|     ResNet      |              ResNet50_vd_KL               |    支持    |    支持    |
 | SwinTransformer |  SwinTransformer_tiny_patch4_window7_224  |    支持    |    支持    |
 
 

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -50,6 +50,8 @@ if [[ ${MODE} = "cpp_infer" ]]; then
         echo "################### build opencv ###################"
         rm -rf ./deploy/cpp/opencv-3.4.7.tar.gz ./deploy/cpp/opencv-3.4.7/
         pushd ./deploy/cpp/
+        wget -nc https://paddle-inference-lib.bj.bcebos.com/2.2.2/cxx_c/Linux/GPU/x86-64_gcc8.2_avx_mkl_cuda10.1_cudnn7.6.5_trt6.0.1.5/paddle_inference.tgz
+        tar xf paddle_inference.tgz
         wget -nc https://paddleocr.bj.bcebos.com/dygraph_v2.0/test/opencv-3.4.7.tar.gz
         tar -xf opencv-3.4.7.tar.gz
 

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -50,8 +50,6 @@ if [[ ${MODE} = "cpp_infer" ]]; then
         echo "################### build opencv ###################"
         rm -rf ./deploy/cpp/opencv-3.4.7.tar.gz ./deploy/cpp/opencv-3.4.7/
         pushd ./deploy/cpp/
-        wget -nc https://paddle-inference-lib.bj.bcebos.com/2.2.2/cxx_c/Linux/GPU/x86-64_gcc8.2_avx_mkl_cuda10.1_cudnn7.6.5_trt6.0.1.5/paddle_inference.tgz
-        tar xf paddle_inference.tgz
         wget -nc https://paddleocr.bj.bcebos.com/dygraph_v2.0/test/opencv-3.4.7.tar.gz
         tar -xf opencv-3.4.7.tar.gz
 
@@ -84,6 +82,12 @@ if [[ ${MODE} = "cpp_infer" ]]; then
         cd ../../
         popd
         echo "################### build opencv finished ###################"
+    fi
+    if [[ ! -d "./deploy/cpp/paddle_inference/" ]]; then
+        pushd ./deploy/cpp/
+        wget -nc https://paddle-inference-lib.bj.bcebos.com/2.2.2/cxx_c/Linux/GPU/x86-64_gcc8.2_avx_mkl_cuda10.1_cudnn7.6.5_trt6.0.1.5/paddle_inference.tgz
+        tar xf paddle_inference.tgz
+        popd
     fi
     if [[ $FILENAME == *infer_cpp_linux_gpu_cpu.txt ]]; then
         cpp_type=$(func_parser_value "${lines[2]}")


### PR DESCRIPTION
1. 增加ResNet50_vd-KL、MobileNetV3_large_x1_0-KL模型的cpp infer，cpp serving，python serving链条，更新相关文档
2. 修复 quant_post_static.py 中量化时batchsize的默认值过大导致报错的问题
3. prepare.sh 增加自动下载并解压 paddle_inference.tar 的命令 