### PR TITLE
Simpify train infer python

### DIFF
--- a/test_tipc/config/AlexNet/AlexNet_train_infer_python.txt
+++ b/test_tipc/config/AlexNet/AlexNet_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/AlexNet/AlexNet_train_infer_python.txt
+++ b/test_tipc/config/AlexNet/AlexNet_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSPNet/CSPDarkNet53_train_infer_python.txt
+++ b/test_tipc/config/CSPNet/CSPDarkNet53_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSPNet/CSPDarkNet53_train_infer_python.txt
+++ b/test_tipc/config/CSPNet/CSPDarkNet53_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_base_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_base_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_base_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_base_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=248
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_base_384_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_base_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_base_384_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_base_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_large_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_large_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_large_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_large_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=248
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_large_384_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_large_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_large_384_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_large_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_small_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_small_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_small_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_small_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=248
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_tiny_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_tiny_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/CSWinTransformer/CSWinTransformer_tiny_224_train_infer_python.txt
+++ b/test_tipc/config/CSWinTransformer/CSWinTransformer_tiny_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=248
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA102_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA102_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA102_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA102_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA102x2_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA102x2_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA102x2_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA102x2_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA102x_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA102x_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA102x_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA102x_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA169_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA169_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA169_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA169_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA34_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA34_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA34_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA34_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA46_c_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA46_c_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA46_c_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA46_c_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA46x_c_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA46x_c_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA46x_c_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA46x_c_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA60_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA60_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA60_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA60_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA60x_c_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA60x_c_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA60x_c_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA60x_c_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DLA/DLA60x_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA60x_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DLA/DLA60x_train_infer_python.txt
+++ b/test_tipc/config/DLA/DLA60x_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DPN/DPN107_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN107_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DPN/DPN107_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN107_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DPN/DPN131_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN131_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DPN/DPN131_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN131_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DPN/DPN68_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN68_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DPN/DPN68_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN68_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DPN/DPN92_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN92_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DPN/DPN92_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN92_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DPN/DPN98_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN98_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DPN/DPN98_train_infer_python.txt
+++ b/test_tipc/config/DPN/DPN98_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DarkNet/DarkNet53_train_infer_python.txt
+++ b/test_tipc/config/DarkNet/DarkNet53_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=292 -o PreProcess.transform_ops.1.CropImage.size=256
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DarkNet/DarkNet53_train_infer_python.txt
+++ b/test_tipc/config/DarkNet/DarkNet53_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DeiT/DeiT_base_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_base_patch16_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DeiT/DeiT_base_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_base_patch16_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DeiT/DeiT_base_patch16_384_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_base_patch16_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384 
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DeiT/DeiT_base_patch16_384_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_base_patch16_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DeiT/DeiT_small_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_small_patch16_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DeiT/DeiT_small_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_small_patch16_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DeiT/DeiT_tiny_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_tiny_patch16_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DeiT/DeiT_tiny_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/DeiT/DeiT_tiny_patch16_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DenseNet/DenseNet121_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet121_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DenseNet/DenseNet121_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet121_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DenseNet/DenseNet161_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet161_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DenseNet/DenseNet161_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet161_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DenseNet/DenseNet169_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet169_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DenseNet/DenseNet169_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet169_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DenseNet/DenseNet201_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet201_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DenseNet/DenseNet201_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet201_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/DenseNet/DenseNet264_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet264_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/DenseNet/DenseNet264_train_infer_python.txt
+++ b/test_tipc/config/DenseNet/DenseNet264_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Distillation/resnet34_distill_resnet18_dkd_train_infer_python.txt
+++ b/test_tipc/config/Distillation/resnet34_distill_resnet18_dkd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Distillation/resnet34_distill_resnet18_dkd_train_infer_python.txt
+++ b/test_tipc/config/Distillation/resnet34_distill_resnet18_dkd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ESNet/ESNet_x0_25_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x0_25_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ESNet/ESNet_x0_25_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x0_25_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ESNet/ESNet_x0_5_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ESNet/ESNet_x0_5_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ESNet/ESNet_x0_75_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x0_75_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ESNet/ESNet_x0_75_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x0_75_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ESNet/ESNet_x1_0_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ESNet/ESNet_x1_0_train_infer_python.txt
+++ b/test_tipc/config/ESNet/ESNet_x1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB0_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB0_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB1_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB1_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB1_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB1_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=272 -o PreProcess.transform_ops.1.CropImage.size=240
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB2_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB2_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB2_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB2_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=292 -o PreProcess.transform_ops.1.CropImage.size=260
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB3_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB3_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB3_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB3_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=332 -o PreProcess.transform_ops.1.CropImage.size=300
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB4_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB4_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=412 -o PreProcess.transform_ops.1.CropImage.size=380
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB4_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB4_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB5_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB5_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=488 -o PreProcess.transform_ops.1.CropImage.size=456
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB6_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB6_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=560 -o PreProcess.transform_ops.1.CropImage.size=528
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB6_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB6_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/EfficientNet/EfficientNetB7_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB7_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml  -o PreProcess.transform_ops.0.ResizeImage.resize_short=632 -o PreProcess.transform_ops.1.CropImage.size=600
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/EfficientNet/EfficientNetB7_train_infer_python.txt
+++ b/test_tipc/config/EfficientNet/EfficientNetB7_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml  -o PreProcess.tra
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_train_infer_python.txt
+++ b/test_tipc/config/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_rec.py -c configs/inference_rec.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.rec_inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/Aliproduct/demo_test/
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/GhostNet/GhostNet_x0_5_train_infer_python.txt
+++ b/test_tipc/config/GhostNet/GhostNet_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/GhostNet/GhostNet_x0_5_train_infer_python.txt
+++ b/test_tipc/config/GhostNet/GhostNet_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/GhostNet/GhostNet_x1_0_train_infer_python.txt
+++ b/test_tipc/config/GhostNet/GhostNet_x1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/GhostNet/GhostNet_x1_0_train_infer_python.txt
+++ b/test_tipc/config/GhostNet/GhostNet_x1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/GhostNet/GhostNet_x1_3_train_infer_python.txt
+++ b/test_tipc/config/GhostNet/GhostNet_x1_3_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/GhostNet/GhostNet_x1_3_train_infer_python.txt
+++ b/test_tipc/config/GhostNet/GhostNet_x1_3_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HRNet/HRNet_W18_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W18_C_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HRNet/HRNet_W18_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W18_C_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HRNet/HRNet_W30_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W30_C_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HRNet/HRNet_W30_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W30_C_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HRNet/HRNet_W32_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W32_C_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HRNet/HRNet_W32_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W32_C_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HRNet/HRNet_W40_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W40_C_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HRNet/HRNet_W40_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W40_C_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HRNet/HRNet_W44_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W44_C_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HRNet/HRNet_W44_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W44_C_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HRNet/HRNet_W48_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W48_C_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/HRNet/HRNet_W48_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W48_C_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HRNet/HRNet_W64_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W64_C_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HRNet/HRNet_W64_C_train_infer_python.txt
+++ b/test_tipc/config/HRNet/HRNet_W64_C_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HarDNet/HarDNet39_ds_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet39_ds_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HarDNet/HarDNet39_ds_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet39_ds_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HarDNet/HarDNet68_ds_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet68_ds_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HarDNet/HarDNet68_ds_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet68_ds_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HarDNet/HarDNet68_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet68_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HarDNet/HarDNet68_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet68_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/HarDNet/HarDNet85_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet85_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/HarDNet/HarDNet85_train_infer_python.txt
+++ b/test_tipc/config/HarDNet/HarDNet85_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Inception/GoogLeNet_train_infer_python.txt
+++ b/test_tipc/config/Inception/GoogLeNet_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Inception/GoogLeNet_train_infer_python.txt
+++ b/test_tipc/config/Inception/GoogLeNet_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Inception/InceptionV3_train_infer_python.txt
+++ b/test_tipc/config/Inception/InceptionV3_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml  -o PreProcess.tra
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Inception/InceptionV3_train_infer_python.txt
+++ b/test_tipc/config/Inception/InceptionV3_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml  -o PreProcess.transform_ops.0.ResizeImage.resize_short=320 -o PreProcess.transform_ops.1.CropImage.size=299
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Inception/InceptionV4_train_infer_python.txt
+++ b/test_tipc/config/Inception/InceptionV4_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml  -o PreProcess.tra
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Inception/InceptionV4_train_infer_python.txt
+++ b/test_tipc/config/Inception/InceptionV4_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml  -o PreProcess.transform_ops.0.ResizeImage.resize_short=320 -o PreProcess.transform_ops.1.CropImage.size=299
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/LeViT/LeViT_128S_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_128S_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/LeViT/LeViT_128S_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_128S_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/LeViT/LeViT_128_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_128_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/LeViT/LeViT_128_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_128_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/LeViT/LeViT_192_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_192_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/LeViT/LeViT_192_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_192_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/LeViT/LeViT_256_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_256_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/LeViT/LeViT_256_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_256_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/LeViT/LeViT_384_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/LeViT/LeViT_384_train_infer_python.txt
+++ b/test_tipc/config/LeViT/LeViT_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MixNet/MixNet_L_train_infer_python.txt
+++ b/test_tipc/config/MixNet/MixNet_L_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MixNet/MixNet_L_train_infer_python.txt
+++ b/test_tipc/config/MixNet/MixNet_L_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MixNet/MixNet_M_train_infer_python.txt
+++ b/test_tipc/config/MixNet/MixNet_M_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MixNet/MixNet_M_train_infer_python.txt
+++ b/test_tipc/config/MixNet/MixNet_M_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MixNet/MixNet_S_train_infer_python.txt
+++ b/test_tipc/config/MixNet/MixNet_S_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MixNet/MixNet_S_train_infer_python.txt
+++ b/test_tipc/config/MixNet/MixNet_S_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV1/MobileNetV1_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/MobileNetV1/MobileNetV1_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV1/MobileNetV1_x0_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_x0_25_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV1/MobileNetV1_x0_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_x0_25_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV1/MobileNetV1_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV1/MobileNetV1_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV1/MobileNetV1_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_x0_75_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV1/MobileNetV1_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV1/MobileNetV1_x0_75_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV2/MobileNetV2_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/MobileNetV2/MobileNetV2_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x0_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x0_25_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x0_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x0_25_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x0_75_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x0_75_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x1_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x1_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x1_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x1_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x2_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x2_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileNetV2/MobileNetV2_x2_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV2/MobileNetV2_x2_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_35_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_35_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_35_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_35_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_75_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x0_75_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
@@ -14,13 +14,13 @@ null:null
 ##
 trainer:norm_train|pact_train|fpgm_train
 norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_large_x1_0.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False
-pact_train:tools/train.py -c ppcls/configs/slim/MobileNetV3_large_x1_0_quantization.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False
-fpgm_train:tools/train.py -c ppcls/configs/slim/MobileNetV3_large_x1_0_prune.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False
+pact_train:null
+fpgm_train:null
 distill_train:null
 to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_large_x1_0.yaml
 null:null
 ##
@@ -28,10 +28,10 @@ null:null
 -o Global.save_inference_dir:./inference
 -o Global.pretrained_model:
 norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_large_x1_0.yaml
-quant_export:tools/export_model.py -c ppcls/configs/slim/MobileNetV3_large_x1_0_quantization.yaml
-fpgm_export:tools/export_model.py -c ppcls/configs/slim/MobileNetV3_large_x1_0_prune.yaml
+quant_export:null
+fpgm_export:null
 distill_export:null
-kl_quant:deploy/slim/quant_post_static.py -c ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_large_x1_0.yaml -o Global.save_inference_dir=./inference
+kl_quant:null
 export2:null
 pretrained_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/legendary_models/MobileNetV3_large_x1_0_pretrained.pdparams
 infer_model:../inference/

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
@@ -12,7 +12,7 @@ train_model_name:latest
 train_infer_img_dir:./dataset/ILSVRC2012/val
 null:null
 ##
-trainer:norm_train|pact_train|fpgm_train
+trainer:norm_train
 norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_large_x1_0.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False
 pact_train:null
 fpgm_train:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_25_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_large_x1_25_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_35_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_35_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_35_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_35_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_5_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_75_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_75_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x0_75_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_0_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_25_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_25_train_infer_python.txt
+++ b/test_tipc/config/MobileNetV3/MobileNetV3_small_x1_25_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileViT/MobileViT_S_train_infer_python.txt
+++ b/test_tipc/config/MobileViT/MobileViT_S_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileViT/MobileViT_S_train_infer_python.txt
+++ b/test_tipc/config/MobileViT/MobileViT_S_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=292 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/MobileViT/MobileViT_XS_train_infer_python.txt
+++ b/test_tipc/config/MobileViT/MobileViT_XS_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=292 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileViT/MobileViT_XS_train_infer_python.txt
+++ b/test_tipc/config/MobileViT/MobileViT_XS_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/MobileViT/MobileViT_XXS_train_infer_python.txt
+++ b/test_tipc/config/MobileViT/MobileViT_XXS_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=292 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/MobileViT/MobileViT_XXS_train_infer_python.txt
+++ b/test_tipc/config/MobileViT/MobileViT_XXS_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPHGNet/PPHGNet_small_train_infer_python.txt
+++ b/test_tipc/config/PPHGNet/PPHGNet_small_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=236
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPHGNet/PPHGNet_small_train_infer_python.txt
+++ b/test_tipc/config/PPHGNet/PPHGNet_small_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPHGNet/PPHGNet_tiny_train_infer_python.txt
+++ b/test_tipc/config/PPHGNet/PPHGNet_tiny_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPHGNet/PPHGNet_tiny_train_infer_python.txt
+++ b/test_tipc/config/PPHGNet/PPHGNet_tiny_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=232
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_25_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_25_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_25_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_25_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_35_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_35_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_35_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_35_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_5_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_5_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_75_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_75_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x0_75_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x0_75_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNet/PPLCNet_x1_0_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x1_0_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNet/PPLCNet_x1_5_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x1_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x1_5_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x1_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNet/PPLCNet_x2_0_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x2_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x2_0_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x2_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNet/PPLCNet_x2_5_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x2_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNet/PPLCNet_x2_5_train_infer_python.txt
+++ b/test_tipc/config/PPLCNet/PPLCNet_x2_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PPLCNetV2/PPLCNetV2_base_train_infer_python.txt
+++ b/test_tipc/config/PPLCNetV2/PPLCNetV2_base_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 ===========================infer_benchmark_params==========================
 random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/config/PPLCNetV2/PPLCNetV2_base_train_infer_python.txt
+++ b/test_tipc/config/PPLCNetV2/PPLCNetV2_base_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PVTV2/PVT_V2_B0_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/PVTV2/PVT_V2_B0_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PVTV2/PVT_V2_B1_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B1_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/PVTV2/PVT_V2_B1_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B1_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PVTV2/PVT_V2_B2_Linear_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B2_Linear_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/PVTV2/PVT_V2_B2_Linear_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B2_Linear_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PVTV2/PVT_V2_B2_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B2_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/PVTV2/PVT_V2_B2_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B2_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PVTV2/PVT_V2_B3_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B3_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/PVTV2/PVT_V2_B3_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B3_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PVTV2/PVT_V2_B4_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B4_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/PVTV2/PVT_V2_B4_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B4_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/PVTV2/PVT_V2_B5_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=256 -o PreProcess.transform_ops.1.CropImage.size=224
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/PVTV2/PVT_V2_B5_train_infer_python.txt
+++ b/test_tipc/config/PVTV2/PVT_V2_B5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ReXNet/ReXNet_1_0_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ReXNet/ReXNet_1_0_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ReXNet/ReXNet_1_3_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_1_3_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ReXNet/ReXNet_1_3_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_1_3_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ReXNet/ReXNet_1_5_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_1_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ReXNet/ReXNet_1_5_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_1_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ReXNet/ReXNet_2_0_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_2_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ReXNet/ReXNet_2_0_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_2_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ReXNet/ReXNet_3_0_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_3_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ReXNet/ReXNet_3_0_train_infer_python.txt
+++ b/test_tipc/config/ReXNet/ReXNet_3_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/RedNet/RedNet101_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet101_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/RedNet/RedNet101_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet101_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/RedNet/RedNet152_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet152_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/RedNet/RedNet152_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet152_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/RedNet/RedNet26_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet26_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/RedNet/RedNet26_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet26_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/RedNet/RedNet38_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet38_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/RedNet/RedNet38_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet38_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/RedNet/RedNet50_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet50_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/RedNet/RedNet50_train_infer_python.txt
+++ b/test_tipc/config/RedNet/RedNet50_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Res2Net/Res2Net101_vd_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net101_vd_26w_4s_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Res2Net/Res2Net101_vd_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net101_vd_26w_4s_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Res2Net/Res2Net200_vd_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net200_vd_26w_4s_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Res2Net/Res2Net200_vd_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net200_vd_26w_4s_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Res2Net/Res2Net50_14w_8s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net50_14w_8s_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Res2Net/Res2Net50_14w_8s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net50_14w_8s_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Res2Net/Res2Net50_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net50_26w_4s_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Res2Net/Res2Net50_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net50_26w_4s_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Res2Net/Res2Net50_vd_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net50_vd_26w_4s_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Res2Net/Res2Net50_vd_26w_4s_train_infer_python.txt
+++ b/test_tipc/config/Res2Net/Res2Net50_vd_26w_4s_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeSt/ResNeSt50_fast_1s1x64d_train_infer_python.txt
+++ b/test_tipc/config/ResNeSt/ResNeSt50_fast_1s1x64d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeSt/ResNeSt50_fast_1s1x64d_train_infer_python.txt
+++ b/test_tipc/config/ResNeSt/ResNeSt50_fast_1s1x64d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeSt/ResNeSt50_train_infer_python.txt
+++ b/test_tipc/config/ResNeSt/ResNeSt50_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeSt/ResNeSt50_train_infer_python.txt
+++ b/test_tipc/config/ResNeSt/ResNeSt50_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt101_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt101_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt101_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_64x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt101_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_64x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt101_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_vd_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt101_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_vd_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt101_vd_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_vd_64x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt101_vd_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt101_vd_64x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt152_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt152_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt152_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_64x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt152_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_64x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt152_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_vd_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt152_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_vd_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt152_vd_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_vd_64x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt152_vd_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt152_vd_64x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt50_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt50_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt50_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_64x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt50_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_64x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt50_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_vd_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt50_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_vd_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNeXt/ResNeXt50_vd_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_vd_64x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNeXt/ResNeXt50_vd_64x4d_train_infer_python.txt
+++ b/test_tipc/config/ResNeXt/ResNeXt50_vd_64x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet101_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet101_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet101_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet101_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet101_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet101_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet101_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet101_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet152_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet152_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet152_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet152_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet152_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet152_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet152_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet152_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet18_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet18_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet18_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet18_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet18_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet18_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet18_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet18_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet200_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet200_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet200_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet200_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet34_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet34_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet34_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet34_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet34_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet34_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet34_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet34_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet50_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet50_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet50_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet50_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt
@@ -12,15 +12,15 @@ train_model_name:latest
 train_infer_img_dir:./dataset/ILSVRC2012/val
 null:null
 ##
-trainer:norm_train|pact_train|fpgm_train
+trainer:norm_train
 norm_train:tools/train.py -c ppcls/configs/ImageNet/ResNet/ResNet50_vd.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False
-pact_train:tools/train.py -c ppcls/configs/slim/ResNet50_vd_quantization.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False
-fpgm_train:tools/train.py -c ppcls/configs/slim/ResNet50_vd_prune.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False
+pact_train:null
+fpgm_train:null
 distill_train:null
 null:null
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/ResNet/ResNet50_vd.yaml
 null:null
 ##
@@ -28,10 +28,10 @@ null:null
 -o Global.save_inference_dir:./inference
 -o Global.pretrained_model:
 norm_export:tools/export_model.py -c ppcls/configs/ImageNet/ResNet/ResNet50_vd.yaml
-quant_export:tools/export_model.py -c ppcls/configs/slim/ResNet50_vd_quantization.yaml
-fpgm_export:tools/export_model.py -c ppcls/configs/slim/ResNet50_vd_prune.yaml
+quant_export:null
+fpgm_export:null
 distill_export:null
-kl_quant:deploy/slim/quant_post_static.py -c ppcls/configs/ImageNet/ResNet/ResNet50_vd.yaml -o Global.save_inference_dir=./inference
+kl_quant:null
 export2:null
 pretrained_model_url:https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/legendary_models/ResNet50_vd_pretrained.pdparams
 infer_model:../inference/

--- a/test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt
+++ b/test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SENet/SENet154_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SENet154_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SENet/SENet154_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SENet154_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SENet/SE_ResNeXt101_32x4d_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNeXt101_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SENet/SE_ResNeXt101_32x4d_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNeXt101_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SENet/SE_ResNeXt50_32x4d_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNeXt50_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SENet/SE_ResNeXt50_32x4d_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNeXt50_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SENet/SE_ResNeXt50_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNeXt50_vd_32x4d_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SENet/SE_ResNeXt50_vd_32x4d_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNeXt50_vd_32x4d_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SENet/SE_ResNet18_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNet18_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SENet/SE_ResNet18_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNet18_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SENet/SE_ResNet34_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNet34_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SENet/SE_ResNet34_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNet34_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SENet/SE_ResNet50_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNet50_vd_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SENet/SE_ResNet50_vd_train_infer_python.txt
+++ b/test_tipc/config/SENet/SE_ResNet50_vd_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_swish_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_swish_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_swish_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_swish_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_25_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_25_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_25_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_25_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_33_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_33_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_33_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_33_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_5_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_5_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x0_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_0_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_0_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_5_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_5_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_5_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x1_5_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x2_0_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x2_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/ShuffleNet/ShuffleNetV2_x2_0_train_infer_python.txt
+++ b/test_tipc/config/ShuffleNet/ShuffleNetV2_x2_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SqueezeNet/SqueezeNet1_0_train_infer_python.txt
+++ b/test_tipc/config/SqueezeNet/SqueezeNet1_0_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SqueezeNet/SqueezeNet1_0_train_infer_python.txt
+++ b/test_tipc/config/SqueezeNet/SqueezeNet1_0_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SqueezeNet/SqueezeNet1_1_train_infer_python.txt
+++ b/test_tipc/config/SqueezeNet/SqueezeNet1_1_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SqueezeNet/SqueezeNet1_1_train_infer_python.txt
+++ b/test_tipc/config/SqueezeNet/SqueezeNet1_1_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window12_384_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window12_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window12_384_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window12_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window7_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_base_patch4_window7_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window12_384_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window12_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window12_384_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window12_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window7_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_large_patch4_window7_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SwinTransformer/SwinTransformer_small_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_small_patch4_window7_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/SwinTransformer/SwinTransformer_small_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_small_patch4_window7_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/SwinTransformer/SwinTransformer_tiny_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_tiny_patch4_window7_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/SwinTransformer/SwinTransformer_tiny_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/config/SwinTransformer/SwinTransformer_tiny_patch4_window7_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/TNT/TNT_small_train_infer_python.txt
+++ b/test_tipc/config/TNT/TNT_small_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/TNT/TNT_small_train_infer_python.txt
+++ b/test_tipc/config/TNT/TNT_small_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Twins/alt_gvt_base_train_infer_python.txt
+++ b/test_tipc/config/Twins/alt_gvt_base_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================train_benchmark_params==========================

--- a/test_tipc/config/Twins/alt_gvt_base_train_infer_python.txt
+++ b/test_tipc/config/Twins/alt_gvt_base_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Twins/alt_gvt_large_train_infer_python.txt
+++ b/test_tipc/config/Twins/alt_gvt_large_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Twins/alt_gvt_large_train_infer_python.txt
+++ b/test_tipc/config/Twins/alt_gvt_large_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Twins/alt_gvt_small_train_infer_python.txt
+++ b/test_tipc/config/Twins/alt_gvt_small_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Twins/alt_gvt_small_train_infer_python.txt
+++ b/test_tipc/config/Twins/alt_gvt_small_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Twins/pcpvt_base_train_infer_python.txt
+++ b/test_tipc/config/Twins/pcpvt_base_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Twins/pcpvt_base_train_infer_python.txt
+++ b/test_tipc/config/Twins/pcpvt_base_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Twins/pcpvt_large_train_infer_python.txt
+++ b/test_tipc/config/Twins/pcpvt_large_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Twins/pcpvt_large_train_infer_python.txt
+++ b/test_tipc/config/Twins/pcpvt_large_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Twins/pcpvt_small_train_infer_python.txt
+++ b/test_tipc/config/Twins/pcpvt_small_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Twins/pcpvt_small_train_infer_python.txt
+++ b/test_tipc/config/Twins/pcpvt_small_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VAN/VAN_tiny_train_infer_python.txt
+++ b/test_tipc/config/VAN/VAN_tiny_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VAN/VAN_tiny_train_infer_python.txt
+++ b/test_tipc/config/VAN/VAN_tiny_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=248 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.5,0.5,0.5] -o PreProcess.transform_ops.2.NormalizeImage.std=[0.5,0.5,0.5]
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VGG/VGG11_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG11_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VGG/VGG11_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG11_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VGG/VGG13_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG13_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VGG/VGG13_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG13_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VGG/VGG16_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG16_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VGG/VGG16_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG16_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VGG/VGG19_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG19_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VGG/VGG19_train_infer_python.txt
+++ b/test_tipc/config/VGG/VGG19_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VisionTransformer/ViT_base_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_base_patch16_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VisionTransformer/ViT_base_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_base_patch16_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VisionTransformer/ViT_base_patch16_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_base_patch16_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VisionTransformer/ViT_base_patch16_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_base_patch16_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VisionTransformer/ViT_base_patch32_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_base_patch32_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VisionTransformer/ViT_base_patch32_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_base_patch32_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VisionTransformer/ViT_large_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_large_patch16_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VisionTransformer/ViT_large_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_large_patch16_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VisionTransformer/ViT_large_patch16_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_large_patch16_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VisionTransformer/ViT_large_patch16_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_large_patch16_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VisionTransformer/ViT_large_patch32_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_large_patch32_384_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=384 -o PreProcess.transform_ops.1.CropImage.size=384
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VisionTransformer/ViT_large_patch32_384_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_large_patch32_384_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/VisionTransformer/ViT_small_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_small_patch16_224_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/VisionTransformer/ViT_small_patch16_224_train_infer_python.txt
+++ b/test_tipc/config/VisionTransformer/ViT_small_patch16_224_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Xception/Xception41_deeplab_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception41_deeplab_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=320 -o PreProcess.transform_ops.1.CropImage.size=299
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Xception/Xception41_deeplab_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception41_deeplab_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Xception/Xception41_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception41_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=320 -o PreProcess.transform_ops.1.CropImage.size=299
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Xception/Xception41_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception41_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Xception/Xception65_deeplab_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception65_deeplab_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=320 -o PreProcess.transform_ops.1.CropImage.size=299
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Xception/Xception65_deeplab_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception65_deeplab_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Xception/Xception65_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception65_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=320 -o PreProcess.transform_ops.1.CropImage.size=299
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Xception/Xception65_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception65_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/config/Xception/Xception71_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception71_train_infer_python.txt
@@ -39,15 +39,15 @@ infer_export:True
 infer_quant:Fasle
 inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=320 -o PreProcess.transform_ops.1.CropImage.size=299
 -o Global.use_gpu:True|False
--o Global.enable_mkldnn:True|False
--o Global.cpu_num_threads:1|6
--o Global.batch_size:1|16
--o Global.use_tensorrt:True|False
--o Global.use_fp16:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
 -o Global.infer_imgs:../dataset/ILSVRC2012/val
 -o Global.save_log_path:null
--o Global.benchmark:True
+-o Global.benchmark:False
 null:null
 null:null
 ===========================infer_benchmark_params==========================

--- a/test_tipc/config/Xception/Xception71_train_infer_python.txt
+++ b/test_tipc/config/Xception/Xception71_train_infer_python.txt
@@ -45,7 +45,7 @@ inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.tran
 -o Global.use_tensorrt:False
 -o Global.use_fp16:False
 -o Global.inference_model_dir:../inference
--o Global.infer_imgs:../dataset/ILSVRC2012/val
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
 -o Global.save_log_path:null
 -o Global.benchmark:False
 null:null

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -172,17 +172,32 @@ if [[ $FILENAME == *use_dali* ]]; then
 fi
 
 if [[ ${MODE} = "lite_train_lite_infer" ]] || [[ ${MODE} = "lite_train_whole_infer" ]]; then
-    # pretrain lite train data
-    cd dataset
-    rm -rf ILSVRC2012
-    wget -nc https://paddle-imagenet-models-name.bj.bcebos.com/data/whole_chain/whole_chain_little_train.tar --no-check-certificate
-    tar xf whole_chain_little_train.tar
-    ln -s whole_chain_little_train ILSVRC2012
-    cd ILSVRC2012
-    mv train.txt train_list.txt
-    mv val.txt val_list.txt
-    cp -r train/* val/
-    cd ../../
+    if [[ ${model_name} =~ "GeneralRecognition" ]]; then
+        cd dataset
+        rm -rf Aliproduct
+        rm -rf train_reg_all_data.txt
+        rm -rf demo_train
+        wget -nc https://paddle-imagenet-models-name.bj.bcebos.com/data/whole_chain/tipc_shitu_demo_data.tar --no-check-certificate
+        tar -xf tipc_shitu_demo_data.tar
+        ln -s tipc_shitu_demo_data Aliproduct
+        ln -s tipc_shitu_demo_data/demo_train.txt train_reg_all_data.txt
+        ln -s tipc_shitu_demo_data/demo_train demo_train
+        cd tipc_shitu_demo_data
+        ln -s demo_test.txt val_list.txt
+        cd ../../
+    else
+        # pretrain lite train data
+        cd dataset
+        rm -rf ILSVRC2012
+        wget -nc https://paddle-imagenet-models-name.bj.bcebos.com/data/whole_chain/whole_chain_little_train.tar --no-check-certificate
+        tar xf whole_chain_little_train.tar
+        ln -s whole_chain_little_train ILSVRC2012
+        cd ILSVRC2012
+        mv train.txt train_list.txt
+        mv val.txt val_list.txt
+        cp -r train/* val/
+        cd ../../
+    fi
     if [[ ${FILENAME} =~ "pact_infer" ]]; then
         # download pretrained model for PACT training
         pretrpretrained_model_url=$(func_parser_value "${lines[35]}")

--- a/test_tipc/test_inference_cpp.sh
+++ b/test_tipc/test_inference_cpp.sh
@@ -64,9 +64,9 @@ function func_shitu_cpp_inference(){
                             precison="int8"
                         fi
                         _save_log_path="${_log_path}/cpp_infer_cpu_usemkldnn_${use_mkldnn}_threads_${threads}_precision_${precision}_batchsize_${batch_size}.log"
-                        eval $transform_index_cmd
                         command="${generate_yaml_cmd} --type shitu --batch_size ${batch_size} --mkldnn ${use_mkldnn} --gpu ${use_gpu} --cpu_thread ${threads} --tensorrt False --precision ${precision} --data_dir ${_img_dir} --benchmark True --cls_model_dir ${cpp_infer_model_dir} --det_model_dir ${cpp_det_infer_model_dir} --gpu_id ${GPUID}"
                         eval $command
+                        eval $transform_index_cmd
                         command="${_script} > ${_save_log_path} 2>&1"
                         eval $command
                         last_status=${PIPESTATUS[0]}
@@ -88,9 +88,9 @@ function func_shitu_cpp_inference(){
                     fi
                     for batch_size in ${cpp_batch_size_list[*]}; do
                         _save_log_path="${_log_path}/cpp_infer_gpu_usetrt_${use_trt}_precision_${precision}_batchsize_${batch_size}.log"
-                        eval $transform_index_cmd
                         command="${generate_yaml_cmd} --type shitu --batch_size ${batch_size} --mkldnn False --gpu ${use_gpu} --cpu_thread 1 --tensorrt ${use_trt} --precision ${precision} --data_dir ${_img_dir} --benchmark True --cls_model_dir ${cpp_infer_model_dir} --det_model_dir ${cpp_det_infer_model_dir} --gpu_id ${GPUID}"
                         eval $command
+                        eval $transform_index_cmd
                         command="${_script} > ${_save_log_path} 2>&1"
                         eval $command
                         last_status=${PIPESTATUS[0]}


### PR DESCRIPTION
1. 简化基础链条的组合，去掉trt和mkldnn，只保留单卡|双卡+CPU|GPU，并关闭benchmark记录功能，避免测试时对autolog包的依赖；简化分类模型的推理输入路径，从`val`文件夹改为单张图片，加快推理速度；删除ResNet50_vd_train_infer_python和MobileNetV3_large_x1_0_train_infer_python配置文件中的冗余配置
2. 修复`test_inference_cpp.sh`脚本，将`transform_index_cmd`命令执行调整至`generate_yaml_cmd`之后，执行顺序与cpp_shitu的文档保持一致，避免yaml找不到的问题