### PR TITLE
fix bechmark

### DIFF
--- a/test_tipc/configs/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
+++ b/test_tipc/configs/MobileNetV3/MobileNetV3_large_x1_0_train_infer_python.txt
@@ -53,7 +53,7 @@ null:null
 ===========================train_benchmark_params==========================
 batch_size:256|640
 fp_items:fp32
-epoch:1
+epoch:2
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
 ===========================infer_benchmark_params==========================

--- a/test_tipc/configs/ShuffleNet/ShuffleNetV2_x1_0_train_infer_python.txt
+++ b/test_tipc/configs/ShuffleNet/ShuffleNetV2_x1_0_train_infer_python.txt
@@ -53,7 +53,7 @@ null:null
 ===========================train_benchmark_params==========================
 batch_size:256|1536
 fp_items:fp32
-epoch:2
+epoch:5
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
 ===========================infer_benchmark_params==========================

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_amp_fp16_DP.sh
@@ -3,7 +3,7 @@ bs_item=256
 fp_item=amp_fp16
 run_mode=DP
 device_num=N1C1
-max_epochs=1
+max_epochs=2
 num_workers=8
 
 # get data

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_fp32_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_fp32_DP.sh
@@ -3,7 +3,7 @@ bs_item=256
 fp_item=fp32
 run_mode=DP
 device_num=N1C1
-max_epochs=1
+max_epochs=2
 num_workers=8
 
 # get data

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_pure_fp16_DP.sh
@@ -3,7 +3,7 @@ bs_item=256
 fp_item=pure_fp16
 run_mode=DP
 device_num=N1C1
-max_epochs=1
+max_epochs=2
 num_workers=8
 
 # get data

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_amp_fp16_DP.sh
@@ -3,7 +3,7 @@ bs_item=256
 fp_item=amp_fp16
 run_mode=DP
 device_num=N1C8
-max_epochs=8
+max_epochs=15
 num_workers=8
 
 # get data

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_fp32_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_fp32_DP.sh
@@ -3,7 +3,7 @@ bs_item=256
 fp_item=fp32
 run_mode=DP
 device_num=N1C8
-max_epochs=8
+max_epochs=15
 num_workers=8
 
 # get data

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_pure_fp16_DP.sh
@@ -3,7 +3,7 @@ bs_item=256
 fp_item=pure_fp16
 run_mode=DP
 device_num=N1C8
-max_epochs=8
+max_epochs=15
 num_workers=8
 
 # get data

--- a/test_tipc/static/ResNet50/benchmark_common/run_benchmark.sh
+++ b/test_tipc/static/ResNet50/benchmark_common/run_benchmark.sh
@@ -63,7 +63,7 @@ function _train(){
     esac
 
     echo "train_cmd: ${train_cmd}  log_file: ${log_file}"
-    timeout 5m ${train_cmd} > ${log_file} 2>&1
+    timeout 10m ${train_cmd} > ${log_file} 2>&1
     if [ $? -ne 0 ];then
         echo -e "${model_name}, FAIL"
     else


### PR DESCRIPTION
 为降低benchmark模型的性能波动，适当增加部分模型的epoch数产出更多有效log