### PR TITLE
add ResNet50 log number in benchmark

### DIFF
--- a/test_tipc/static/ResNet50/benchmark_common/prepare.sh
+++ b/test_tipc/static/ResNet50/benchmark_common/prepare.sh
@@ -7,5 +7,7 @@ wget -nc https://paddle-imagenet-models-name.bj.bcebos.com/data/ImageNet1k/ILSVR
 tar xf ILSVRC2012_val.tar
 ln -s ILSVRC2012_val ILSVRC2012
 cd ILSVRC2012
-ln -s val_list.txt  train_list.txt
+for ((i=1; i<=4; i++));do
+  cat val_list.txt >> train_list.txt
+done
 cd ../../

--- a/test_tipc/static/ResNet50/benchmark_common/run_benchmark.sh
+++ b/test_tipc/static/ResNet50/benchmark_common/run_benchmark.sh
@@ -63,7 +63,7 @@ function _train(){
     esac
 
     echo "train_cmd: ${train_cmd}  log_file: ${log_file}"
-    timeout 5m ${train_cmd} > ${log_file} 2>&1
+    timeout 10m ${train_cmd} > ${log_file} 2>&1
     if [ $? -ne 0 ];then
         echo -e "${model_name}, FAIL"
     else


### PR DESCRIPTION
修复benchmark 静态图训练中ResNet50 日志较少的情况