### PR TITLE
[TIPC] add scripts for NPU and XPU, test=develop

### DIFF
--- a/deploy/utils/predictor.py
+++ b/deploy/utils/predictor.py
@@ -65,7 +65,8 @@ class Predictor(object):
         elif args.get("use_npu", False):
             config.enable_npu()
         elif args.get("use_xpu", False):
-            config.enalbe_xpu()
+            config.enable_lite_engine()
+            config.enable_xpu(10 * 1024 * 1024)
         else:
             config.disable_gpu()
             if args.enable_mkldnn:

--- a/deploy/utils/predictor.py
+++ b/deploy/utils/predictor.py
@@ -60,8 +60,12 @@ class Predictor(object):
 
         config = Config(model_file, params_file)
 
-        if args.use_gpu:
+        if args.get("use_gpu", False):
             config.enable_use_gpu(args.gpu_mem, 0)
+        elif args.get("use_npu", False):
+            config.enable_npu()
+        elif args.get("use_xpu", False):
+            config.enalbe_xpu()
         else:
             config.disable_gpu()
             if args.enable_mkldnn:

--- a/test_tipc/docs/test_train_inference_python.md
+++ b/test_tipc/docs/test_train_inference_python.md
@@ -49,7 +49,16 @@ Linux端基础训练预测功能测试的主程序为`test_train_inference_pytho
    # 如果要测试量化、裁剪等功能，需要安装PaddleSlim
    pip3 install paddleslim
    ```
-
+- 准备昇腾测试代码 (可选)
+  ```
+  # 先执行以下脚本，准备昇腾的测试代码
+  bash test_tipc/prepare_npu_test.sh
+  ```
+- 准备昆仑测试代码 (可选)
+  ```
+  # 先执行以下脚本，准备昆仑的测试代码
+  bash test_tipc/prepare_xpu_test.sh
+  ```
 
 ### 2.2 功能测试
 先运行`prepare.sh`准备数据和模型，然后运行`test_train_inference_python.sh`进行测试，最终在```test_tipc/output```目录下生成`python_infer_*.log`格式的日志文件。

--- a/test_tipc/prepare_npu_test.sh
+++ b/test_tipc/prepare_npu_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+BASEDIR=$(dirname "$0")
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+config_files=$(find ${REPO_ROOT_PATH}/test_tipc/configs -name "*.txt")
+for file in ${config_files}; do
+   sed -i "s/Global.device:gpu/Global.device:npu/g" $file
+   sed -i "s/Global.use_gpu/Global.use_npu/g" $file
+done
+
+config_files=$(find ${REPO_ROOT_PATH}/ppcls/configs -name "*.yaml")
+for file in ${config_files}; do
+   sed -i "s/device: gpu/device: npu/g" $file
+done
+
+config_files=$(find ${REPO_ROOT_PATH}/deploy/configs -name "*.yaml")
+for file in ${config_files}; do
+   sed -i "s/use_gpu: True/use_npu: True/g" $file
+done

--- a/test_tipc/prepare_xpu_test.sh
+++ b/test_tipc/prepare_xpu_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+BASEDIR=$(dirname "$0")
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+config_files=$(find ${REPO_ROOT_PATH}/test_tipc/configs -name "*.txt")
+for file in ${config_files}; do
+   sed -i "s/Global.device:gpu/Global.device:xpu/g" $file
+   sed -i "s/Global.use_gpu/Global.use_xpu/g" $file
+done
+
+config_files=$(find ${REPO_ROOT_PATH}/ppcls/configs -name "*.yaml")
+for file in ${config_files}; do
+   sed -i "s/device: gpu/device: xpu/g" $file
+done
+
+config_files=$(find ${REPO_ROOT_PATH}/deploy/configs -name "*.yaml")
+for file in ${config_files}; do
+   sed -i "s/use_gpu: True/use_xpu: True/g" $file
+done

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -259,9 +259,9 @@ else
                 if [ ${#gpu} -le 2 ]; then # train with cpu or single gpu
                     cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} "
                 elif [ ${#ips} -le 15 ]; then # train with multi-gpu
-                    cmd="${python} -m paddle.distributed.launch --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1}"
+                    cmd="${python} -m paddle.distributed.launch --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1}"
                 else # train with multi-machine
-                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1}"
+                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1}"
                 fi
                 # run train
                 eval "unset CUDA_VISIBLE_DEVICES"


### PR DESCRIPTION
### 为昇腾和昆仑测试添加 TIPC 代码

1. test_tipc/test_train_inference_python.sh 中将 --gpus 换成 --devices，不影响 GPU 测试
2. deploy/utils/predictor.py 修改代码支持接受 use_gpu / use_npu / use_xpu 输入，且 use_gpu 可以为空
3. test_tipc/prepare_npu_test.sh 和 test_tipc/prepare_xpu_test.sh 分别修改 TIPC 运行在 NPU 和 XPU 下所需配置

### 正常 GPU 下运行测试命令如下：

```bash
# 设置运行卡号
export CUDA_VISIBLE_DEVICES=0,1

# 准备小数据集
bash test_tipc/prepare.sh \
     test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt \
     'lite_train_lite_infer'

# 运行单测模型
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ResNet/ResNet50_vd_train_infer_python.txt \
     'lite_train_lite_infer'
```

运行结果如下，测试通过，不影响 GPU 下的 TIPC 运行

![image](https://user-images.githubusercontent.com/16605440/183824133-247d29af-5e88-402b-b7f9-b7b27e437290.png)

### 昇腾下运行测试命令如下：

```bash
# 准备昇腾代码
bash test_tipc/prepare_npu_test.sh

# 准备小数据集
bash test_tipc/prepare.sh \
     test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt \
     'lite_train_lite_infer'

# 运行单测模型
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ResNet/ResNet50_vd_train_infer_python.txt \
     'lite_train_lite_infer'
```

运行结果为：

![image](https://user-images.githubusercontent.com/16605440/183642797-fc17b2aa-677e-4c9b-8b37-fb2ac5483d23.png)


### 昆仑下运行测试命令如下：

```bash
# 准备昆仑代码
bash test_tipc/prepare_xpu_test.sh

# 准备小数据集
bash test_tipc/prepare.sh \
     test_tipc/config/ResNet/ResNet50_vd_train_infer_python.txt \
     'lite_train_lite_infer'

# 运行单测模型
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ResNet/ResNet50_vd_train_infer_python.txt \
     'lite_train_lite_infer'
```

运行结果如下：

![image](https://user-images.githubusercontent.com/16605440/183643014-30c61600-8ede-48e6-aadb-1d036dab0d9e.png)

昆仑环境下无法支持分布式的运行，昆仑同学正在定位修复中。


