### PR TITLE
[TIPC] Add scripts for NPU and XPU

### DIFF
--- a/deploy/utils/predictor.py
+++ b/deploy/utils/predictor.py
@@ -60,8 +60,12 @@ class Predictor(object):
 
         config = Config(model_file, params_file)
 
-        if args.use_gpu:
+        if args.get("use_gpu", False):
             config.enable_use_gpu(args.gpu_mem, 0)
+        elif args.get("use_npu", False):
+            config.enable_npu()
+        elif args.get("use_xpu", False):
+            config.enable_xpu()
         else:
             config.disable_gpu()
             if args.enable_mkldnn:

--- a/test_tipc/common_func.sh
+++ b/test_tipc/common_func.sh
@@ -83,3 +83,11 @@ function status_check(){
         echo -e "\033[33m Run failed with command - ${model_name} - ${run_command}!  \033[0m" | tee -a ${run_log}
     fi
 }
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -20,7 +20,7 @@ python=$(func_parser_value "${lines[2]}")
 gpu_list=$(func_parser_value "${lines[3]}")
 train_use_gpu_key=$(func_parser_key "${lines[4]}")
 train_use_gpu_value=$(func_parser_value "${lines[4]}")
-if [ ${DEVICE} != "gpu" ]; then
+if [ "${DEVICE}" != "gpu" ]; then
     train_use_gpu_value=$(echo $train_use_gpu_value | sed -e "s/gpu/${DEVICE}/g") # replace gpu to ${DEVICE}
 fi
 autocast_list=$(func_parser_value "${lines[5]}")
@@ -75,7 +75,7 @@ infer_is_quant=$(func_parser_value "${lines[38]}")
 # parser inference
 inference_py=$(func_parser_value "${lines[39]}")
 use_gpu_key=$(func_parser_key "${lines[40]}")
-if [ ${DEVICE} != "gpu" ]; then
+if [ "${DEVICE}" != "gpu" ]; then
     use_gpu_key=$(echo $use_gpu_key | sed -e "s/gpu/${DEVICE}/g") # replace gpu to ${DEVICE}
 fi
 use_gpu_list=$(func_parser_value "${lines[40]}")
@@ -181,7 +181,7 @@ if [[ ${MODE} = "whole_infer" ]]; then
         cd ../../deploy
         is_quant=True
         # replace use_gpu to use_${DEVICE} in inference config
-        if [ ${DEVICE} != "gpu" ]; then
+        if [ "${DEVICE}" != "gpu" ]; then
             inference_config=$(func_parser_config "${inference_py}")
             sed -i "s/use_gpu: True/use_${DEVICE}: True/g" $inference_config
         fi
@@ -271,7 +271,7 @@ else
 
                 # replace device: gpu to device: ${DEVICE} in trainer config file
                 # replace once as run_train/eval_py/run_export share same config file
-                if [ ${DEVICE} != "gpu" ]; then
+                if [ "${DEVICE}" != "gpu" ]; then
                     trainer_config=$(func_parser_config "${run_train}")
                     sed -i "s/device: gpu/device: ${DEVICE}/g" $trainer_config
                 fi
@@ -328,7 +328,7 @@ else
                     save_infer_path="${save_log}"
                     cd deploy
                     # replace use_gpu to use_npu in inference config
-                    if [ ${DEVICE} != "gpu" ]; then
+                    if [ "${DEVICE}" != "gpu" ]; then
                         inference_config=$(func_parser_config "${inference_py}")
                         sed -i "s/use_gpu: True/use_${DEVICE}: True/g" $inference_config
                     fi

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -ex
-
 FILENAME=$1
 source test_tipc/common_func.sh
 


### PR DESCRIPTION
为昇腾910添加 TIPC 测试脚本，测试步骤如下：

```bash
# 准备小数据集
bash test_tipc/prepare.sh \
     test_tipc/config/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer'

# GPU上运行单测模型，脚本保持不变，默认输入设备为 GPU
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer'

# NPU上运行单测模型，注意这里的脚本最后需要输入小写 npu
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer' npu

# XPU上运行单测模型，注意这里的脚本最后需要输入小写 xpu
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer' xpu
```

昇腾910上运行结果如下：

![image](https://user-images.githubusercontent.com/16605440/188790716-ab7a1e58-d59f-4c61-8dad-7b41354ebb69.png)

昆仑R200上运行结果如下：
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/16605440/188903228-09862e42-d5a4-48c7-a8f5-b02b2bc6ec4c.png">


Duplicated with https://github.com/PaddlePaddle/PaddleClas/pull/2194
