### PR TITLE
[TIPC] add scripts for npu and xpu, test=develop

### DIFF
--- a/deploy/utils/predictor.py
+++ b/deploy/utils/predictor.py
@@ -60,8 +60,12 @@ class Predictor(object):
 
         config = Config(model_file, params_file)
 
-        if args.use_gpu:
+        if args.get("use_gpu", False):
             config.enable_use_gpu(args.gpu_mem, 0)
+        elif args.get("use_npu", False):
+            config.enable_npu()
+        elif args.get("use_xpu", False):
+            config.enable_xpu()
         else:
             config.disable_gpu()
             if args.enable_mkldnn:

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# change gpu to npu in tipc txt configs
+sed -i "s/Global.device:gpu/Global.device:npu/g" $FILENAME
+sed -i "s/Global.use_gpu/Global.use_npu/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# replace inference config file
+inference_py=$(func_parser_value "${lines[39]}")
+inference_config=$(func_parser_config ${inference_py})
+sed -i 's/use_gpu: True/use_npu: True/g' "$REPO_ROOT_PATH/deploy/$inference_config"
+
+# replace training config file
+grep -n 'tools/.*yaml' $FILENAME  | cut -d ":" -f 1 \
+| while read line_num ; do 
+    train_cmd=$(func_parser_value "${lines[line_num-1]}")
+    trainer_config=$(func_parser_config ${train_cmd})
+    sed -i 's/device: gpu/device: npu/g' "$REPO_ROOT_PATH/$trainer_config"
+done
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+function readlinkf() {
+    perl -MCwd -e 'print Cwd::abs_path shift' "$1";
+}
+
+function func_parser_config() {
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[2]}
+    echo ${tmp}
+}
+
+BASEDIR=$(dirname "$0")
+REPO_ROOT_PATH=$(readlinkf ${BASEDIR}/../)
+
+FILENAME=$1
+
+# change gpu to xpu in tipc txt configs
+sed -i "s/Global.device:gpu/Global.device:xpu/g" $FILENAME
+sed -i "s/Global.use_gpu/Global.use_xpu/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+
+# replace inference config file
+inference_py=$(func_parser_value "${lines[39]}")
+inference_config=$(func_parser_config ${inference_py})
+sed -i 's/use_gpu: True/use_xpu: True/g' "$REPO_ROOT_PATH/deploy/$inference_config"
+
+# replace training config file
+grep -n 'tools/.*yaml' $FILENAME  | cut -d ":" -f 1 \
+| while read line_num ; do 
+    train_cmd=$(func_parser_value "${lines[line_num-1]}")
+    trainer_config=$(func_parser_config ${train_cmd})
+    sed -i 's/device: gpu/device: xpu/g' "$REPO_ROOT_PATH/$trainer_config"
+done
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo $cmd
+eval $cmd


### PR DESCRIPTION
为昇腾和昆仑设备添加 TIPC 脚本，补充 PR https://github.com/PaddlePaddle/PaddleClas/pull/2284

```bash
# 准备小数据集
bash test_tipc/prepare.sh \
     test_tipc/config/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer'

# GPU上运行单测模型，脚本保持不变
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer'

# NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
bash test_tipc/test_train_inference_python_npu.sh \
     test_tipc/configs/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer'

# XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
bash test_tipc/test_train_inference_python_xpu.sh \
     test_tipc/configs/ResNet/ResNet50_train_infer_python.txt \
     'lite_train_lite_infer'
```

昆仑R200运行结果如下：

![image](https://user-images.githubusercontent.com/16605440/189102907-0b7f42a9-5248-453d-bf46-be376cd42c16.png)

昇腾910运行结果如下：
