### PR TITLE
tipc: set num_workers to 4

### DIFF
--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs128_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs128_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N1C1
 max_epochs=1
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs128_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs128_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N1C1
 max_epochs=1
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N1C1
 max_epochs=1
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs256_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N1C1
 max_epochs=1
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs64_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs64_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N1C1
 max_epochs=1
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C1/ResNet50_bs64_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C1/ResNet50_bs64_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N1C1
 max_epochs=1
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs128_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs128_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N1C8
 max_epochs=8
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs128_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs128_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N1C8
 max_epochs=8
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N1C8
 max_epochs=8
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs256_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N1C8
 max_epochs=8
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs64_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs64_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N1C8
 max_epochs=8
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N1C8/ResNet50_bs64_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N1C8/ResNet50_bs64_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N1C8
 max_epochs=8
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N4C32/ResNet50_bs128_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N4C32/ResNet50_bs128_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N4C32
 max_epochs=32
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N4C32/ResNet50_bs128_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N4C32/ResNet50_bs128_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N4C32
 max_epochs=32
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N4C32/ResNet50_bs256_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N4C32/ResNet50_bs256_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N4C32
 max_epochs=32
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N4C32/ResNet50_bs256_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N4C32/ResNet50_bs256_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N4C32
 max_epochs=32
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N4C32/ResNet50_bs64_amp_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N4C32/ResNet50_bs64_amp_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=amp_fp16
 run_mode=DP
 device_num=N4C32
 max_epochs=32
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh

--- a/test_tipc/static/ResNet50/N4C32/ResNet50_bs64_pure_fp16_DP.sh
+++ b/test_tipc/static/ResNet50/N4C32/ResNet50_bs64_pure_fp16_DP.sh
@@ -4,7 +4,7 @@ fp_item=pure_fp16
 run_mode=DP
 device_num=N4C32
 max_epochs=32
-num_workers=8
+num_workers=4
 
 # get data
 bash test_tipc/static/${model_item}/benchmark_common/prepare.sh


### PR DESCRIPTION
The benchmark requires threads num to be set 4 when DALI is used for best performance. And the param num_workers is not worked before commit 80c10bb99503eeb349a5d676bd0af4908a74b425.