### PR TITLE
Fix problems of ResNet50_bs128_fp32_DP performance.

### DIFF
--- a/test_tipc/static/ResNet50/N4C32/ResNet50_bs128_fp32_DP.sh
+++ b/test_tipc/static/ResNet50/N4C32/ResNet50_bs128_fp32_DP.sh
@@ -3,7 +3,7 @@ bs_item=128
 fp_item=fp32
 run_mode=DP
 device_num=N4C32
-max_epochs=32
+max_epochs=1
 num_workers=8
 
 # get data

--- a/test_tipc/static/ResNet50/benchmark_common/prepare.sh
+++ b/test_tipc/static/ResNet50/benchmark_common/prepare.sh
@@ -7,7 +7,7 @@ wget -nc https://paddle-imagenet-models-name.bj.bcebos.com/data/ImageNet1k/ILSVR
 tar xf ILSVRC2012_val.tar
 ln -s ILSVRC2012_val ILSVRC2012
 cd ILSVRC2012
-for ((i=1; i<=4; i++));do
+for ((i=1; i<=15; i++));do
   cat val_list.txt >> train_list.txt
 done
 cd ../../


### PR DESCRIPTION
When use smalle dataset in N4C32 training, log contains only first 10 iterations statics in each epoch, and statics of the first 5 warmup iterations are ignored in PaddleClas, which leads to inaccurate higher ips.