### PR TITLE
Fix GeneralRecognitionV2 benchmark TIPC

### DIFF
--- a/test_tipc/README.md
+++ b/test_tipc/README.md
@@ -115,3 +115,4 @@ bash test_tipc/test_train_inference_python.sh ./test_tipc/configs/MobileNetV3/Mo
 - [test_serving_infer_python 使用](docs/test_serving_infer_python.md)：测试python serving功能。
 - [test_serving_infer_cpp 使用](docs/test_serving_infer_cpp.md)：测试cpp serving功能。
 - [test_train_fleet_inference_python 使用](./docs/test_train_fleet_inference_python.md)：测试基于Python的多机多卡训练与推理等基本功能。
+- [benchmark_train 使用](./docs/benchmark_train.md)：测试基于Python的训练benchmark等基本功能。

--- a/test_tipc/configs/GeneralRecognitionV2/GeneralRecognitionV2_PPLCNetV2_base_train_infer_python.txt
+++ b/test_tipc/configs/GeneralRecognitionV2/GeneralRecognitionV2_PPLCNetV2_base_train_infer_python.txt
@@ -51,7 +51,7 @@ inference:python/predict_rec.py -c configs/inference_rec.yaml
 null:null
 null:null
 ===========================train_benchmark_params==========================
-batch_size:256
+batch_size:128
 fp_items:fp32|fp16
 epoch:1
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile


### PR DESCRIPTION
1. 修复`GeneralRecognitionV2`模型batchsize过大导致无法运行benchmarktrain的问题
    由于`GeneralRecognitionV2`使用的是`PKSampler`，该采样器对batchsize有一定要求，原配置文件不满足`50x4>256`，因此将 benchmark 中的batchsize从256改小为128，这样就满足了`50x4>128`，训练结果为
    ```log
    {"model_branch": null, "model_commit": null, "model_name": 
    "GeneralRecognitionV2_PPLCNetV2_base_bs8_fp32_DP", "batch_size": 8, "fp_item": "fp32", "run_mode": 
    "DP", "convergence_value": "6.26898", "convergence_key": "loss:", "ips": 109.6, "speed_unit": 
    "samples/s", "device_num": "N1C1", "model_run_time": "87", "frame_commit": 
    "369154744d3e1136d7ac96b754dcf7642f28b4a9", "frame_version": "0.0.0"}
    ```
3. 完善PKsampler的一处断言提示，统一参数名和成员变量名为`sample_per_id`
4. TIPC首页文档加入`benchmark_train`链条的入口