### PR TITLE
tipc: fix the keyword of ShiTu model 

### DIFF
--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -274,7 +274,7 @@ else
                 # export FLAGS_cudnn_deterministic=True
                 sleep 5
                 eval $cmd
-                if [[ $FILENAME == *GeneralRecognition* ]]; then
+                if [[ $model_name == *GeneralRecognition* ]]; then
                     eval "cat ${save_log}/RecModel/train.log >> ${save_log}.log"
                 else
                     eval "cat ${save_log}/${model_name}/train.log >> ${save_log}.log"
@@ -282,7 +282,7 @@ else
                 status_check $? "${cmd}" "${status_log}" "${model_name}" "${save_log}.log"
                 sleep 5
 
-                if [[ $FILENAME == *GeneralRecognition* ]]; then
+                if [[ $model_name == *GeneralRecognition* ]]; then
                     set_eval_pretrain=$(func_set_params "${pretrain_model_key}" "${save_log}/RecModel/${train_model_name}")
                 else
                     set_eval_pretrain=$(func_set_params "${pretrain_model_key}" "${save_log}/${model_name}/${train_model_name}")
@@ -304,7 +304,7 @@ else
                 if [ ${run_export} != "null" ]; then
                     # run export model
                     save_infer_path="${save_log}"
-                    if [[ $FILENAME == *GeneralRecognition* ]]; then
+                    if [[ $model_name == *GeneralRecognition* ]]; then
                         set_eval_pretrain=$(func_set_params "${pretrain_model_key}" "${save_log}/RecModel/${train_model_name}")
                     else
                         set_export_weight=$(func_set_params "${export_weight}" "${save_log}/${model_name}/${train_model_name}")


### PR DESCRIPTION
In benchmark_train mode, the config name is benchmark.txt. So the keyword of ShiTu should be model_name instead of the config name.