### PR TITLE
fix Constant learning rate bug

### DIFF
--- a/ppcls/configs/reid/strong_baseline/softmax_triplet_with_center.yaml
+++ b/ppcls/configs/reid/strong_baseline/softmax_triplet_with_center.yaml
@@ -87,7 +87,7 @@ Optimizer:
   - SGD:
       scope: CenterLoss
       lr:
-        name: Constant
+        name: ConstLR
         learning_rate: 1000.0 # NOTE: set to ori_lr*(1/centerloss_weight) to avoid manually scaling centers' gradidents.
 
 # data loader for train and eval

--- a/ppcls/optimizer/learning_rate.py
+++ b/ppcls/optimizer/learning_rate.py
@@ -93,6 +93,25 @@ class LRBase(object):
         return warmup_lr
 
 
+class ConstantImpl(lr.LRScheduler):
+    """Constant learning rate Class implementation
+
+    Args:
+        learning_rate (float): The initial learning rate
+        last_epoch (int, optional): The index of last epoch. Default: -1.
+    """
+
+    def __init__(self, learning_rate, last_epoch=-1, **kwargs):
+        self.learning_rate = learning_rate
+        self.last_epoch = last_epoch
+        super(ConstantImpl, self).__init__()
+
+    def get_lr(self) -> float:
+        """always return the same learning rate
+        """
+        return self.learning_rate
+
+
 class Constant(LRBase):
     """Constant learning rate
 
@@ -120,16 +139,8 @@ class Constant(LRBase):
                                        last_epoch, by_epoch)
 
     def __call__(self):
-        learning_rate = lr.LRScheduler(
+        learning_rate = ConstantImpl(
             learning_rate=self.learning_rate, last_epoch=self.last_epoch)
-
-        def make_get_lr():
-            def get_lr(self):
-                return self.learning_rate
-
-            return get_lr
-
-        setattr(learning_rate, "get_lr", make_get_lr())
 
         if self.warmup_steps > 0:
             learning_rate = self.linear_warmup(learning_rate)

--- a/ppcls/optimizer/learning_rate.py
+++ b/ppcls/optimizer/learning_rate.py
@@ -93,7 +93,7 @@ class LRBase(object):
         return warmup_lr
 
 
-class ConstantImpl(lr.LRScheduler):
+class Constant(lr.LRScheduler):
     """Constant learning rate Class implementation
 
     Args:
@@ -104,7 +104,7 @@ class ConstantImpl(lr.LRScheduler):
     def __init__(self, learning_rate, last_epoch=-1, **kwargs):
         self.learning_rate = learning_rate
         self.last_epoch = last_epoch
-        super(ConstantImpl, self).__init__()
+        super(Constant, self).__init__()
 
     def get_lr(self) -> float:
         """always return the same learning rate
@@ -112,7 +112,7 @@ class ConstantImpl(lr.LRScheduler):
         return self.learning_rate
 
 
-class Constant(LRBase):
+class ConstLR(LRBase):
     """Constant learning rate
 
     Args:
@@ -134,12 +134,12 @@ class Constant(LRBase):
                  last_epoch=-1,
                  by_epoch=False,
                  **kwargs):
-        super(Constant, self).__init__(epochs, step_each_epoch, learning_rate,
-                                       warmup_epoch, warmup_start_lr,
-                                       last_epoch, by_epoch)
+        super(ConstLR, self).__init__(epochs, step_each_epoch, learning_rate,
+                                      warmup_epoch, warmup_start_lr,
+                                      last_epoch, by_epoch)
 
     def __call__(self):
-        learning_rate = ConstantImpl(
+        learning_rate = Constant(
             learning_rate=self.learning_rate, last_epoch=self.last_epoch)
 
         if self.warmup_steps > 0:


### PR DESCRIPTION
1. 修复Constant学习率无法调用`step`方法的问题，影响模型：`softmax_triplet_with_center.yaml`