### PR TITLE
[TIPC]Polish benchmark_train.sh for dynamicTostatic

### DIFF
--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -139,6 +139,13 @@ if [[ ! -n "$PARAMS" ]];then
     fp_items_list=(${fp_items})
     device_num_list=(N1C4)
     run_mode="DP"
+elif [[ ${PARAMS} = "dynamicTostatic" ]];then
+    IFS="|"
+    model_type=$PARAMS
+    batch_size_list=(${batch_size})
+    fp_items_list=(${fp_items})
+    device_num_list=(N1C4)
+    run_mode="DP"
 else
     # parser params from input: modeltype_bs${bs_item}_${fp_item}_${run_mode}_${device_num}
     IFS="_"


### PR DESCRIPTION
修改benchmark脚本，使其执行如 `bash test_tipc/benchmark_train.sh /workspace/PaddleClas/test_tipc/configs/MobileNetV1/MobileNetV1_train_infer_python.txt benchmark_train dynamicTostatic` 命令时可以测试模型的所有配置