### PR TITLE
Fix tensor conversion in static mode with dali loader

### DIFF
--- a/ppcls/data/dataloader/dali.py
+++ b/ppcls/data/dataloader/dali.py
@@ -142,13 +142,18 @@ class HybridValPipe(Pipeline):
 
 
 class DALIImageNetIterator(DALIGenericIterator):
+    def __init__(self, *kargs, **kwargs):
+        super(DALIImageNetIterator, self).__init__(*kargs, **kwargs)
+        self.in_dynamic_mode = paddle.in_dynamic_mode()
+
     def __next__(self) -> List[paddle.Tensor]:
         data_batch = super(DALIImageNetIterator,
                            self).__next__()  # List[Dict[str, Tensor], ...]
-
         # reformat to List[Tensor1, Tensor2, ...]
         data_batch = [
-            paddle.to_tensor(data_batch[0][key]) for key in self.output_map
+            paddle.to_tensor(data_batch[0][key])
+            if self.in_dynamic_mode else data_batch[0][key]
+            for key in self.output_map
         ]
         return data_batch
 

--- a/ppcls/static/program.py
+++ b/ppcls/static/program.py
@@ -386,15 +386,11 @@ def run(dataloader,
 
         profiler.add_profiler_step(profiler_options)
 
-        if use_dali:
-            batch_size = batch[0]["data"].shape()[0]
-            feed_dict = batch[0]
-        else:
-            batch_size = batch[0].shape()[0]
-            feed_dict = {
-                key.name: batch[idx]
-                for idx, key in enumerate(feeds.values())
-            }
+        batch_size = batch[0].shape()[0]
+        feed_dict = {
+            key.name: batch[idx]
+            for idx, key in enumerate(feeds.values())
+        }
 
         metrics = exe.run(program=program,
                           feed=feed_dict,


### PR DESCRIPTION
1. 修复`DALIImageNetIterator`在静态图仍然会调用`paddle.to_tensor`导致报错的BUG。
```log
ppcls INFO: epoch:0   train step:10   lr: 0.100000, loss: 15.2720 top1:  0.0000 top5:  0.0000 batch_cost: 0.11290 s, reader_cost: 0.06370 s, ips: 1133.74330 samples/sec.
ppcls INFO: epoch:0   train step:20   lr: 0.100000, loss:  7.8510 top1:  0.0000 top5:  0.0078 batch_cost: 0.10513 s, reader_cost: 0.05988 s, ips: 1217.53896 samples/sec.
ppcls INFO: epoch:0   train step:30   lr: 0.100000, loss:  7.2569 top1:  0.0078 top5:  0.0234 batch_cost: 0.10343 s, reader_cost: 0.05874 s, ips: 1237.58405 samples/sec.
ppcls INFO: epoch:0   train step:40   lr: 0.100000, loss:  7.1149 top1:  0.0000 top5:  0.0078 batch_cost: 0.10251 s, reader_cost: 0.05842 s, ips: 1248.69922 samples/sec.
ppcls INFO: epoch:0   train step:50   lr: 0.100000, loss:  6.9607 top1:  0.0000 top5:  0.0078 batch_cost: 0.10204 s, reader_cost: 0.05816 s, ips: 1254.36447 samples/sec.
ppcls INFO: epoch:0   train step:60   lr: 0.100000, loss:  6.9279 top1:  0.0000 top5:  0.0000 batch_cost: 0.10172 s, reader_cost: 0.05805 s, ips: 1258.40414 samples/sec.
ppcls INFO: epoch:0   train step:70   lr: 0.100000, loss:  6.9370 top1:  0.0000 top5:  0.0000 batch_cost: 0.10148 s, reader_cost: 0.05796 s, ips: 1261.29416 samples/sec.
ppcls INFO: epoch:0   train step:80   lr: 0.100000, loss:  6.9182 top1:  0.0078 top5:  0.0234 batch_cost: 0.10134 s, reader_cost: 0.05790 s, ips: 1263.05671 samples/sec.
ppcls INFO: epoch:0   train step:90   lr: 0.100000, loss:  6.9056 top1:  0.0078 top5:  0.0078 batch_cost: 0.10123 s, reader_cost: 0.05784 s, ips: 1264.46080 samples/sec.
ppcls INFO: epoch:0   train step:100  lr: 0.100000, loss:  6.8914 top1:  0.0000 top5:  0.0000 batch_cost: 0.10125 s, reader_cost: 0.05773 s, ips: 1264.14447 samples/sec.
....
....
```