### PR TITLE
Remove Global.to_static in yaml

### DIFF
--- a/docs/zh_CN/training/config_description/basic.md
+++ b/docs/zh_CN/training/config_description/basic.md
@@ -54,7 +54,6 @@
 | image_shape | 图片大小 | [3, 224, 224] | list, shape: (3,) |
 | save_inference_dir | inference 模型的保存路径 | "./inference" | str |
 | eval_mode | eval 的模式 | "classification" | "retrieval" |
-| to_static | 是否改为静态图模式 | False | True |
 | ues_dali | 是否使用 dali 库进行图像预处理 | False | True |
 
 **注**：`pretrained_model` 也可以填写存放预训练模型的 http 地址。

--- a/ppcls/arch/__init__.py
+++ b/ppcls/arch/__init__.py
@@ -49,16 +49,13 @@ def build_model(config, mode="train"):
 
 
 def apply_to_static(config, model):
-    support_to_static = config['Global'].get('to_static', False)
-
-    if support_to_static:
-        specs = None
-        if 'image_shape' in config['Global']:
-            specs = [InputSpec([None] + config['Global']['image_shape'])]
-            specs[0].stop_gradient = True
-        model = to_static(model, input_spec=specs)
-        logger.info("Successfully to apply @to_static with specs: {}".format(
-            specs))
+    specs = None
+    if 'image_shape' in config['Global']:
+        specs = [InputSpec([None] + config['Global']['image_shape'])]
+        specs[0].stop_gradient = True
+    model = to_static(model, input_spec=specs)
+    logger.info("Successfully to apply @to_static with specs: {}".format(
+        specs))
     return model
 
 

--- a/ppcls/configs/DeepHash/DCH.yaml
+++ b/ppcls/configs/DeepHash/DCH.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
   #feature postprocess
   feature_normalize: False

--- a/ppcls/configs/DeepHash/DSHSD.yaml
+++ b/ppcls/configs/DeepHash/DSHSD.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
   #feature postprocess
   feature_normalize: False

--- a/ppcls/configs/DeepHash/LCDSH.yaml
+++ b/ppcls/configs/DeepHash/LCDSH.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
   #feature postprocess
   feature_normalize: False

--- a/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5.yaml
+++ b/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_binary.yaml
+++ b/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_binary.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
   #feature postprocess
   feature_normalize: False

--- a/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_dml.yaml
+++ b/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_dml.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_udml.yaml
+++ b/ppcls/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_udml.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/CSPNet/CSPDarkNet53.yaml
+++ b/ppcls/configs/ImageNet/CSPNet/CSPDarkNet53.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_base_224.yaml
+++ b/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_base_224.yaml
@@ -14,8 +14,8 @@ Global:
 
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_base_384.yaml
+++ b/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_base_384.yaml
@@ -14,8 +14,8 @@ Global:
 
   image_shape: [3, 384, 384]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_large_224.yaml
+++ b/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_large_224.yaml
@@ -14,8 +14,8 @@ Global:
 
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_large_384.yaml
+++ b/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_large_384.yaml
@@ -14,8 +14,8 @@ Global:
 
   image_shape: [3, 384, 384]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_small_224.yaml
+++ b/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_small_224.yaml
@@ -14,8 +14,8 @@ Global:
 
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_tiny_224.yaml
+++ b/ppcls/configs/ImageNet/CSWinTransformer/CSWinTransformer_tiny_224.yaml
@@ -14,8 +14,8 @@ Global:
 
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ConvNeXt/ConvNeXt_tiny.yaml
+++ b/ppcls/configs/ImageNet/ConvNeXt/ConvNeXt_tiny.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   update_freq: 4  # for 8 cards
 
 # model ema

--- a/ppcls/configs/ImageNet/Distillation/PPLCNet_x2_5_ssld.yaml
+++ b/ppcls/configs/ImageNet/Distillation/PPLCNet_x2_5_ssld.yaml
@@ -13,7 +13,7 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  to_static: True
+  
 
 AMP:
   scale_loss: 128.0

--- a/ppcls/configs/ImageNet/Distillation/resnet34_distill_resnet18_dist.yaml
+++ b/ppcls/configs/ImageNet/Distillation/resnet34_distill_resnet18_dist.yaml
@@ -13,7 +13,7 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  to_static: False
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/Distillation/resnet34_distill_resnet18_mgd.yaml
+++ b/ppcls/configs/ImageNet/Distillation/resnet34_distill_resnet18_mgd.yaml
@@ -13,7 +13,7 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  to_static: False
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/MixNet/MixNet_L.yaml
+++ b/ppcls/configs/ImageNet/MixNet/MixNet_L.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/MixNet/MixNet_M.yaml
+++ b/ppcls/configs/ImageNet/MixNet/MixNet_M.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/MixNet/MixNet_S.yaml
+++ b/ppcls/configs/ImageNet/MixNet/MixNet_S.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/MobileNetV1/MobileNetV1.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV1/MobileNetV1.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/MobileNetV2/MobileNetV2.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV2/MobileNetV2.yaml
@@ -13,8 +13,6 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PPHGNet/PPHGNet_base.yaml
+++ b/ppcls/configs/ImageNet/PPHGNet/PPHGNet_base.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/ImageNet/PPHGNet/PPHGNet_small.yaml
+++ b/ppcls/configs/ImageNet/PPHGNet/PPHGNet_small.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/ImageNet/PPHGNet/PPHGNet_tiny.yaml
+++ b/ppcls/configs/ImageNet/PPHGNet/PPHGNet_tiny.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/ImageNet/PVTV2/PVT_V2_B0.yaml
+++ b/ppcls/configs/ImageNet/PVTV2/PVT_V2_B0.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PVTV2/PVT_V2_B1.yaml
+++ b/ppcls/configs/ImageNet/PVTV2/PVT_V2_B1.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PVTV2/PVT_V2_B2.yaml
+++ b/ppcls/configs/ImageNet/PVTV2/PVT_V2_B2.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PVTV2/PVT_V2_B2_Linear.yaml
+++ b/ppcls/configs/ImageNet/PVTV2/PVT_V2_B2_Linear.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PVTV2/PVT_V2_B3.yaml
+++ b/ppcls/configs/ImageNet/PVTV2/PVT_V2_B3.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PVTV2/PVT_V2_B4.yaml
+++ b/ppcls/configs/ImageNet/PVTV2/PVT_V2_B4.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PVTV2/PVT_V2_B5.yaml
+++ b/ppcls/configs/ImageNet/PVTV2/PVT_V2_B5.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/PeleeNet/PeleeNet.yaml
+++ b/ppcls/configs/ImageNet/PeleeNet/PeleeNet.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ReXNet/ReXNet_1_0.yaml
+++ b/ppcls/configs/ImageNet/ReXNet/ReXNet_1_0.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ReXNet/ReXNet_1_3.yaml
+++ b/ppcls/configs/ImageNet/ReXNet/ReXNet_1_3.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ReXNet/ReXNet_1_5.yaml
+++ b/ppcls/configs/ImageNet/ReXNet/ReXNet_1_5.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ReXNet/ReXNet_2_0.yaml
+++ b/ppcls/configs/ImageNet/ReXNet/ReXNet_2_0.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ReXNet/ReXNet_3_0.yaml
+++ b/ppcls/configs/ImageNet/ReXNet/ReXNet_3_0.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet101.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet101.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet152.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet152.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet50.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O1.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O1.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: True
 
 # mixed precision training

--- a/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O1_ultra.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O1_ultra.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [*image_channel, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: True
 
 # mixed precision training

--- a/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O2_ultra.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50_amp_O2_ultra.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [*image_channel, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: True
 
 # mixed precision training

--- a/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_base_patch4_window12_384.yaml
+++ b/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_base_patch4_window12_384.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 384, 384]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_base_patch4_window7_224.yaml
+++ b/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_base_patch4_window7_224.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_large_patch4_window12_384.yaml
+++ b/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_large_patch4_window12_384.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 384, 384]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_large_patch4_window7_224.yaml
+++ b/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_large_patch4_window7_224.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_small_patch4_window7_224.yaml
+++ b/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_small_patch4_window7_224.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/Twins/alt_gvt_base.yaml
+++ b/ppcls/configs/ImageNet/Twins/alt_gvt_base.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/Twins/alt_gvt_large.yaml
+++ b/ppcls/configs/ImageNet/Twins/alt_gvt_large.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/Twins/alt_gvt_small.yaml
+++ b/ppcls/configs/ImageNet/Twins/alt_gvt_small.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/Twins/pcpvt_base.yaml
+++ b/ppcls/configs/ImageNet/Twins/pcpvt_base.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/Twins/pcpvt_large.yaml
+++ b/ppcls/configs/ImageNet/Twins/pcpvt_large.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/Twins/pcpvt_small.yaml
+++ b/ppcls/configs/ImageNet/Twins/pcpvt_small.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/ImageNet/VAN/VAN_B0.yaml
+++ b/ppcls/configs/ImageNet/VAN/VAN_B0.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/PULC/car_exists/MobileNetV3_small_x0_35.yaml
+++ b/ppcls/configs/PULC/car_exists/MobileNetV3_small_x0_35.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/car_exists/PPLCNet_x1_0.yaml
+++ b/ppcls/configs/PULC/car_exists/PPLCNet_x1_0.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/car_exists/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/car_exists/PPLCNet_x1_0_distillation.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/car_exists/PPLCNet_x1_0_search.yaml
+++ b/ppcls/configs/PULC/car_exists/PPLCNet_x1_0_search.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/car_exists/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/PULC/car_exists/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/PULC/code_exists/MobileNetV3_small_x0_35.yaml
+++ b/ppcls/configs/PULC/code_exists/MobileNetV3_small_x0_35.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/code_exists/PPLCNet_x1_0.yaml
+++ b/ppcls/configs/PULC/code_exists/PPLCNet_x1_0.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/code_exists/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/code_exists/PPLCNet_x1_0_distillation.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/code_exists/PPLCNet_x1_0_search.yaml
+++ b/ppcls/configs/PULC/code_exists/PPLCNet_x1_0_search.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/code_exists/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/PULC/code_exists/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/PULC/language_classification/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/language_classification/PPLCNet_x1_0_distillation.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/language_classification/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/PULC/language_classification/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/PULC/person_attribute/PPLCNet_x1_0_Distillation.yaml
+++ b/ppcls/configs/PULC/person_attribute/PPLCNet_x1_0_Distillation.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 256, 192]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
   use_multilabel: True
 

--- a/ppcls/configs/PULC/person_exists/MobileNetV3_small_x0_35.yaml
+++ b/ppcls/configs/PULC/person_exists/MobileNetV3_small_x0_35.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/person_exists/PPLCNet_x1_0.yaml
+++ b/ppcls/configs/PULC/person_exists/PPLCNet_x1_0.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/person_exists/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/person_exists/PPLCNet_x1_0_distillation.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/person_exists/PPLCNet_x1_0_search.yaml
+++ b/ppcls/configs/PULC/person_exists/PPLCNet_x1_0_search.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/person_exists/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/PULC/person_exists/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/PULC/safety_helmet/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/safety_helmet/PPLCNet_x1_0_distillation.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/text_image_orientation/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/text_image_orientation/PPLCNet_x1_0_distillation.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/text_image_orientation/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/PULC/text_image_orientation/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/PULC/textline_orientation/MobileNetV3_small_x0_35.yaml
+++ b/ppcls/configs/PULC/textline_orientation/MobileNetV3_small_x0_35.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0.yaml
+++ b/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 80, 160]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0_224x224.yaml
+++ b/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0_224x224.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0_distillation.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 80, 160]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0_search.yaml
+++ b/ppcls/configs/PULC/textline_orientation/PPLCNet_x1_0_search.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 48, 192]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/PULC/textline_orientation/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/PULC/textline_orientation/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/PULC/traffic_sign/PPLCNet_x1_0.yaml
+++ b/ppcls/configs/PULC/traffic_sign/PPLCNet_x1_0.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/traffic_sign/PPLCNet_x1_0_distillation.yaml
+++ b/ppcls/configs/PULC/traffic_sign/PPLCNet_x1_0_distillation.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/PULC/traffic_sign/PPLCNet_x1_0_search.yaml
+++ b/ppcls/configs/PULC/traffic_sign/PPLCNet_x1_0_search.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 

--- a/ppcls/configs/PULC/traffic_sign/SwinTransformer_tiny_patch4_window7_224.yaml
+++ b/ppcls/configs/PULC/traffic_sign/SwinTransformer_tiny_patch4_window7_224.yaml
@@ -14,8 +14,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # mixed precision training

--- a/ppcls/configs/multi_scale/MobileNetV1_multi_scale.yaml
+++ b/ppcls/configs/multi_scale/MobileNetV1_multi_scale.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
 
 # model architecture
 Arch:

--- a/ppcls/configs/practical_models/PPHGNet_tiny_calling_halfbody.yaml
+++ b/ppcls/configs/practical_models/PPHGNet_tiny_calling_halfbody.yaml
@@ -13,8 +13,8 @@ Global:
   # used for static mode and model export
   image_shape: [3, 224, 224]
   save_inference_dir: ./inference
-  # training model under @to_static
-  to_static: False
+  
+  
   use_dali: False
 
 # model architecture

--- a/ppcls/configs/slim/GeneralRecognition_PPLCNet_x2_5_quantization.yaml
+++ b/ppcls/configs/slim/GeneralRecognition_PPLCNet_x2_5_quantization.yaml
@@ -15,7 +15,7 @@ Global:
   save_inference_dir: ./inference
   eval_mode: retrieval
   use_dali: False
-  to_static: False
+  
 
 # for quantizaiton or prune model
 Slim:

--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -126,16 +126,18 @@ class Engine(object):
                 self.config["DataLoader"], "Train", self.device, self.use_dali)
             if self.config["DataLoader"].get('UnLabelTrain', None) is not None:
                 self.unlabel_train_dataloader = build_dataloader(
-                        self.config["DataLoader"], "UnLabelTrain", self.device,
-                        self.use_dali)
+                    self.config["DataLoader"], "UnLabelTrain", self.device,
+                    self.use_dali)
             else:
                 self.unlabel_train_dataloader = None
 
-            self.iter_per_epoch = len(self.train_dataloader) - 1 if platform.system(
+            self.iter_per_epoch = len(
+                self.train_dataloader) - 1 if platform.system(
                 ) == "Windows" else len(self.train_dataloader)
             if self.config["Global"].get("iter_per_epoch", None):
                 # set max iteration per epoch mannualy, when training by iteration(s), such as XBM, FixMatch.
-                self.iter_per_epoch = self.config["Global"].get("iter_per_epoch")
+                self.iter_per_epoch = self.config["Global"].get(
+                    "iter_per_epoch")
             self.iter_per_epoch = self.iter_per_epoch // self.update_freq * self.update_freq
 
         if self.mode == "eval" or (self.mode == "train" and
@@ -213,7 +215,8 @@ class Engine(object):
         # build model
         self.model = build_model(self.config, self.mode)
         # set @to_static for benchmark, skip this by default.
-        apply_to_static(self.config, self.model)
+        if config['Global'].get('to_static', False):
+            apply_to_static(self.config, self.model)
 
         # load_pretrain
         if self.config["Global"]["pretrained_model"] is not None:


### PR DESCRIPTION
根据@宇宁的要求，删除yaml中关于to_static 的配置，避免对yaml的侵入式修改。保留 -o Global.to_static=True 运行时修改，以确保动转静性能监控正常执行