### PR TITLE
fix ResNet50_ReID

### DIFF
--- a/ppcls/configs/Logo/ResNet50_ReID.yaml
+++ b/ppcls/configs/Logo/ResNet50_ReID.yaml
@@ -32,7 +32,7 @@ Arch:
   Head:
     name: "CircleMargin"
     margin: 0.35
-    scale:  64
+    scale: 64
     embedding_size: 512
     class_num: 3000
 
@@ -56,42 +56,43 @@ Optimizer:
     name: Cosine
     learning_rate: 0.04
   regularizer:
-    name: 'L2'
+    name: "L2"
     coeff: 0.0001
 
 # data loader for train and eval
 DataLoader:
   Train:
     dataset:
-        name: ImageNetDataset
-        image_root: "dataset/LogoDet-3K-crop/train/"
-        cls_label_path: "dataset/LogoDet-3K-crop/train_list.txt"
-        transform_ops:
-          - DecodeImage:
-              to_rgb: True
-              channel_first: False
-          - ResizeImage:
-              size: 224
-          - RandFlipImage:
-              flip_code: 1
-          - AugMix:
-              prob: 0.5
-          - NormalizeImage:
-              scale: 0.00392157
-              mean: [0.485, 0.456, 0.406]
-              std: [0.229, 0.224, 0.225]
-              order: ''
-          - RandomErasing:
-              EPSILON: 0.5
+      name: ImageNetDataset
+      image_root: "dataset/LogoDet-3K-crop/train/"
+      cls_label_path: "dataset/LogoDet-3K-crop/train_list.txt"
+      relabel: True
+      transform_ops:
+        - DecodeImage:
+            to_rgb: True
+            channel_first: False
+        - ResizeImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - AugMix:
+            prob: 0.5
+        - NormalizeImage:
+            scale: 0.00392157
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ""
+        - RandomErasing:
+            EPSILON: 0.5
     sampler:
-        name: PKSampler
-        batch_size: 128
-        sample_per_id: 2
-        drop_last: True
+      name: PKSampler
+      batch_size: 128
+      sample_per_id: 2
+      drop_last: True
 
     loader:
-        num_workers: 6
-        use_shared_memory: True
+      num_workers: 6
+      use_shared_memory: True
   Eval:
     Query:
       dataset:
@@ -108,44 +109,43 @@ DataLoader:
               scale: 0.00392157
               mean: [0.485, 0.456, 0.406]
               std: [0.229, 0.224, 0.225]
-              order: ''
+              order: ""
       sampler:
-          name: DistributedBatchSampler
-          batch_size: 128
-          drop_last: False
-          shuffle: False
+        name: DistributedBatchSampler
+        batch_size: 128
+        drop_last: False
+        shuffle: False
       loader:
-          num_workers: 8
-          use_shared_memory: True
+        num_workers: 8
+        use_shared_memory: True
 
     Gallery:
       dataset:
-          name: ImageNetDataset
-          image_root: "dataset/LogoDet-3K-crop/train/"
-          cls_label_path: "dataset/LogoDet-3K-crop/train_list.txt"
-          transform_ops:
-            - DecodeImage:
-                to_rgb: True
-                channel_first: False
-            - ResizeImage:
-                size: 224
-            - NormalizeImage:
-                scale: 0.00392157
-                mean: [0.485, 0.456, 0.406]
-                std: [0.229, 0.224, 0.225]
-                order: ''
+        name: ImageNetDataset
+        image_root: "dataset/LogoDet-3K-crop/train/"
+        cls_label_path: "dataset/LogoDet-3K-crop/train_list.txt"
+        transform_ops:
+          - DecodeImage:
+              to_rgb: True
+              channel_first: False
+          - ResizeImage:
+              size: 224
+          - NormalizeImage:
+              scale: 0.00392157
+              mean: [0.485, 0.456, 0.406]
+              std: [0.229, 0.224, 0.225]
+              order: ""
       sampler:
-          name: DistributedBatchSampler
-          batch_size: 128
-          drop_last: False
-          shuffle: False
+        name: DistributedBatchSampler
+        batch_size: 128
+        drop_last: False
+        shuffle: False
       loader:
-          num_workers: 8
-          use_shared_memory: True
+        num_workers: 8
+        use_shared_memory: True
 
 Metric:
   Eval:
     - Recallk:
         topk: [1, 5]
     - mAP: {}
-


### PR DESCRIPTION
1. 修复ResNet50_ReID.yaml对LogoDet-3K-crop数据集训练时，没有将label重新映射到[0,3000)，导致F.one_hot报错的问题。
2. 对ResNet50_ReID.yaml进行了格式化