### PR TITLE
fix Pillow DeprecationWarning in python deploy

### DIFF
--- a/deploy/python/preprocess.py
+++ b/deploy/python/preprocess.py
@@ -64,13 +64,13 @@ class UnifiedResize(object):
             'random': (cv2.INTER_LINEAR, cv2.INTER_CUBIC)
         }
         _pil_interp_from_str = {
-            'nearest': Image.NEAREST,
-            'bilinear': Image.BILINEAR,
-            'bicubic': Image.BICUBIC,
-            'box': Image.BOX,
-            'lanczos': Image.LANCZOS,
-            'hamming': Image.HAMMING,
-            'random': (Image.BILINEAR, Image.BICUBIC)
+            'nearest': Image.Resampling.NEAREST,
+            'bilinear': Image.Resampling.BILINEAR,
+            'bicubic': Image.Resampling.BICUBIC,
+            'box': Image.Resampling.BOX,
+            'lanczos': Image.Resampling.LANCZOS,
+            'hamming': Image.Resampling.HAMMING,
+            'random': (Image.Resampling.BILINEAR, Image.Resampling.BICUBIC)
         }
 
         def _cv2_resize(src, size, resample):

--- a/deploy/python/preprocess.py
+++ b/deploy/python/preprocess.py
@@ -31,6 +31,10 @@ from paddle.vision.transforms import ToTensor, Normalize
 
 from paddleclas.deploy.python.det_preprocess import DetNormalizeImage, DetPadStride, DetPermute, DetResize
 
+# Pillow<9.0
+if not hasattr(Image, 'Resampling'):
+    Image.Resampling = Image
+
 
 def create_operators(params):
     """


### PR DESCRIPTION
fix Pillow DeprecationWarning in python deploy

before
```
[2022-12-14 09:44:01,634] [ WARNING] logger.py:73 - A new filed (use_onnx) detected!
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:67: DeprecationWarning: NEAREST is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.NEAREST or Dither.NONE instead.
  'nearest': Image.NEAREST,
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:68: DeprecationWarning: BILINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BILINEAR instead.
  'bilinear': Image.BILINEAR,
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:69: DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
  'bicubic': Image.BICUBIC,
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:70: DeprecationWarning: BOX is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BOX instead.
  'box': Image.BOX,
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:71: DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
  'lanczos': Image.LANCZOS,
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:72: DeprecationWarning: HAMMING is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.HAMMING instead.
  'hamming': Image.HAMMING,
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:73: DeprecationWarning: BILINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BILINEAR instead.
  'random': (Image.BILINEAR, Image.BICUBIC)
/home/greatx/repos/PaddleClas/venv/lib/python3.10/site-packages/paddleclas-0.0.0-py3.10.egg/paddleclas/deploy/python/preprocess.py:73: DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
  'random': (Image.BILINEAR, Image.BICUBIC)
ILSVRC2012_val_00000010.jpeg:   class id(s): [2, 7, 1, 4, 14], score(s): [0.64, 0.14, 0.12, 0.04, 0.02], label_name(s): ['great white shark, white shark, man-eater, man-eating shark, Carcharodon carcharias', 'cock', 'goldfish, Carassius auratus', 'hammerhead, hammerhead shark', 'indigo bunting, indigo finch, indigo bird, Passerina cyanea']
```

after
```
[2022-12-14 09:59:31,833] [ WARNING] logger.py:73 - A new filed (use_onnx) detected!
ILSVRC2012_val_00000010.jpeg:   class id(s): [2, 7, 1, 4, 14], score(s): [0.64, 0.14, 0.12, 0.04, 0.02], label_name(s): ['great white shark, white shark, man-eater, man-eating shark, Carcharodon carcharias', 'cock', 'goldfish, Carassius auratus', 'hammerhead, hammerhead shark', 'indigo bunting, indigo finch, indigo bird, Passerina cyanea']
```