### PR TITLE
fix retrieval for windows

### DIFF
--- a/ppcls/engine/evaluation/retrieval.py
+++ b/ppcls/engine/evaluation/retrieval.py
@@ -125,12 +125,8 @@ def compute_feature(engine, name="gallery"):
     all_feat = []
     all_label = []
     all_camera = []
-    max_iter = len(dataloader) - 1 if platform.system() == "Windows" else len(
-        dataloader)
     has_camera = False
     for idx, batch in enumerate(dataloader):  # load is very time-consuming
-        if idx >= max_iter:
-            break
         if idx % engine.config["Global"]["print_batch_step"] == 0:
             logger.info(
                 f"{name} feature calculation process: [{idx}/{len(dataloader)}]"


### PR DESCRIPTION
1. 删除`retrieval.py`关于`max_iter`的内容，防止windows下数据量较少的时候收集到空数据的问题