### PR TITLE
remove with_data_parallel in program.compile

### DIFF
--- a/ppcls/static/train.py
+++ b/ppcls/static/train.py
@@ -171,7 +171,10 @@ def main(args):
         compiled_train_prog = train_prog
 
     if eval_dataloader is not None:
-        compiled_eval_prog = program.compile(config, eval_prog)
+        if not global_config.get("is_distributed", True):
+            compiled_eval_prog = program.compile(config, eval_prog)
+        else:
+            compiled_eval_prog = eval_prog
 
     for epoch_id in range(global_config["epochs"]):
         # 1. train with train dataset


### PR DESCRIPTION
`with_data_parallel`这一接口原本用于开启单机多卡训练，然而，由于paddle执行器升级的原因，这一接口预计于paddle2.5版本废弃，改为通过fleet方式进行单机多卡训练。
`PaddleClas`目前默认通过fleet方式进行多卡训练，因此不需要做额外修改，直接去除`with_data_parallel`即可。

API `with_data_parallel` is used to training on multi gpus with a single machine. However, it will be deprecated in paddle2.5 since the executor of paddle updated and replaced with `fleet`.
`PaddleClas` is already using `fleet` to training on multi gpus. So removed `with_data_parallel` and there's no need to do extra changes