### PR TITLE
fix(dali): reset dataloader manually

### DIFF
--- a/ppcls/engine/train/train.py
+++ b/ppcls/engine/train/train.py
@@ -30,6 +30,9 @@ def train_epoch(engine, epoch_id, print_batch_step):
         try:
             batch = next(engine.train_dataloader_iter)
         except Exception:
+            # NOTE: reset DALI dataloader manually
+            if engine.use_dali:
+                engine.train_dataloader.reset()
             engine.train_dataloader_iter = iter(engine.train_dataloader)
             batch = next(engine.train_dataloader_iter)
 


### PR DESCRIPTION
1. 修复DALI Dataloader抛出`StopIteration`后，未及时手动reset重置dali的数据读取索引，导致获取数据异常，最后报错的问题