### PR TITLE
add to_static_train:-o Global.to_static=True

### DIFF
--- a/test_tipc/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_train_infer_python.txt
+++ b/test_tipc/configs/GeneralRecognition/GeneralRecognition_PPLCNet_x2_5_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/GeneralRecognition/GeneralRecognition
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/GeneralRecognitionV2/GeneralRecognitionV2_PPLCNetV2_base_train_infer_python.txt
+++ b/test_tipc/configs/GeneralRecognitionV2/GeneralRecognitionV2_PPLCNetV2_base_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/GeneralRecognitionV2/GeneralRecogniti
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/HRNet/HRNet_W18_C_train_infer_python.txt
+++ b/test_tipc/configs/HRNet/HRNet_W18_C_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/HRNet/HRNet_W18_C.yaml -o Gl
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/PPHGNet/PPHGNet_small_train_infer_python.txt
+++ b/test_tipc/configs/PPHGNet/PPHGNet_small_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPHGNet/PPHGNet_small.yaml -
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/PPHGNet/PPHGNet_tiny_train_infer_python.txt
+++ b/test_tipc/configs/PPHGNet/PPHGNet_tiny_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPHGNet/PPHGNet_tiny.yaml -o
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/PPLCNet/PPLCNet_x0_25_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x0_25_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_25.yaml -
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_25.yaml
 null:null
 ##

--- a/test_tipc/configs/PPLCNet/PPLCNet_x0_35_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x0_35_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_35.yaml -
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_35.yaml
 null:null
 ##

--- a/test_tipc/configs/PPLCNet/PPLCNet_x0_5_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x0_5_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_5.yaml -o
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_5.yaml
 null:null
 ##

--- a/test_tipc/configs/PPLCNet/PPLCNet_x0_75_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x0_75_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_75.yaml -
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x0_75.yaml
 null:null
 ##

--- a/test_tipc/configs/PPLCNet/PPLCNet_x1_0_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x1_0_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x1_0.yaml -o
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x1_0.yaml
 null:null
 ##

--- a/test_tipc/configs/PPLCNet/PPLCNet_x1_5_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x1_5_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x1_5.yaml -o
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x1_5.yaml
 null:null
 ##

--- a/test_tipc/configs/PPLCNet/PPLCNet_x2_0_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x2_0_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x2_0.yaml -o
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x2_0.yaml
 null:null
 ##

--- a/test_tipc/configs/PPLCNet/PPLCNet_x2_5_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNet/PPLCNet_x2_5_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNet/PPLCNet_x2_5.yaml -o
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/PPLCNetV2/PPLCNetV2_base_train_infer_python.txt
+++ b/test_tipc/configs/PPLCNetV2/PPLCNetV2_base_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PPLCNetV2/PPLCNetV2_base.yam
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/PVTV2/PVT_V2_B2_Linear_train_infer_python.txt
+++ b/test_tipc/configs/PVTV2/PVT_V2_B2_Linear_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/PVTV2/PVT_V2_B2_Linear.yaml 
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/ResNeXt/ResNeXt50_32x4d_train_infer_python.txt
+++ b/test_tipc/configs/ResNeXt/ResNeXt50_32x4d_train_infer_python.txt
@@ -17,10 +17,10 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/ResNeXt/ResNeXt50_32x4d.yaml
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
-===========================eval_params=========================== 
+===========================eval_params===========================
 eval:tools/eval.py -c ppcls/configs/ImageNet/ResNeXt/ResNeXt50_32x4d.yaml
 null:null
 ##

--- a/test_tipc/configs/ResNet/ResNet50_vd_train_infer_python.txt
+++ b/test_tipc/configs/ResNet/ResNet50_vd_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/ResNet/ResNet50_vd.yaml -o G
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/SwinTransformer/SwinTransformer_tiny_patch4_window7_224_train_infer_python.txt
+++ b/test_tipc/configs/SwinTransformer/SwinTransformer_tiny_patch4_window7_224_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/SwinTransformer/SwinTransfor
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/Twins/alt_gvt_base_train_infer_python.txt
+++ b/test_tipc/configs/Twins/alt_gvt_base_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/Twins/alt_gvt_base.yaml -o G
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================

--- a/test_tipc/configs/Twins/alt_gvt_small_train_infer_python.txt
+++ b/test_tipc/configs/Twins/alt_gvt_small_train_infer_python.txt
@@ -17,7 +17,7 @@ norm_train:tools/train.py -c ppcls/configs/ImageNet/Twins/alt_gvt_small.yaml -o 
 pact_train:null
 fpgm_train:null
 distill_train:null
-null:null
+to_static_train:-o Global.to_static=True
 null:null
 ##
 ===========================eval_params===========================


### PR DESCRIPTION
PR（https://github.com/PaddlePaddle/PaddleClas/pull/2690） 中 SwinTransformer_tiny_patch4_window7_224和ResNeXt50_32x4d两个模型的d2s字段未生效，更新后复测结果如下图所示，与提测时指标相差不大：

<img width="900" alt="截屏2023-03-08 17 52 45" src="https://user-images.githubusercontent.com/12560511/223680694-4a9c6e96-b4d2-4832-a3e2-bca7a3901e2a.png">

