### PR TITLE
[飞桨黑客松第四期] (128) MobileViTv3

### DIFF
--- a/docs/zh_CN/models/ImageNet1k/MobileViTv3.md
+++ b/docs/zh_CN/models/ImageNet1k/MobileViTv3.md
@@ -1,0 +1,108 @@
+# MobileviTv3
+-----
+
+## 目录
+
+- [1. 模型介绍](#1)
+    - [1.1 模型简介](#1.1)
+    - [1.2 模型指标](#1.2)
+- [2. 模型快速体验](#2)
+- [3. 模型训练、评估和预测](#3)
+- [4. 模型推理部署](#4)
+  - [4.1 推理模型准备](#4.1)
+  - [4.2 基于 Python 预测引擎推理](#4.2)
+  - [4.3 基于 C++ 预测引擎推理](#4.3)
+  - [4.4 服务化部署](#4.4)
+  - [4.5 端侧部署](#4.5)
+  - [4.6 Paddle2ONNX 模型转换与预测](#4.6)
+
+<a name='1'></a>
+
+## 1. 模型介绍
+
+<a name='1.1'></a>
+
+### 1.1 模型简介
+
+MobileViTv3 是一个结合 CNN 和 ViT 的轻量级模型，用于移动视觉任务。通过 MobileViTv3-block 解决了 MobileViTv1 的扩展问题并简化了学习任务，从而得倒了 MobileViTv3-XXS、XS 和 S 模型，在 ImageNet-1k、ADE20K、COCO 和 PascalVOC2012 数据集上表现优于 MobileViTv1。
+通过将提出的融合块添加到 MobileViTv2 中，创建 MobileViTv3-0.5、0.75 和 1.0 模型，在ImageNet-1k、ADE20K、COCO和PascalVOC2012数据集上给出了比 MobileViTv2 更好的准确性数据。[论文地址](https://arxiv.org/abs/2209.15159)。
+
+<a name='1.2'></a>
+
+### 1.2 模型指标
+
+| Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPs<br>(G) | Params<br>(M) |
+|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| MobileViTv3_XXS    | 0.7087 | 0.8976 | 0.7098 | - |  289.02 | 1.25 |
+| MobileViTv3_XS     | 0.7663 | 0.9332 | 0.7671 | - |  926.98 | 2.49 |
+| MobileViTv3_S      | 0.7928 | 0.9454 | 0.7930 | - | 1841.39 | 5.76 |
+| MobileViTv3_XXS_L2 | 0.7028 | 0.8942 | 0.7023 | - |  256.97 | 1.15 |
+| MobileViTv3_XS_L2  | 0.7607 | 0.9300 | 0.7610 | - |  852.82 | 2.26 |
+| MobileViTv3_S_L2   | 0.7907 | 0.9440 | 0.7906 | - | 1651.96 | 5.17 |
+| MobileViTv3_x0_5   | 0.7200 | 0.9083 | 0.7233 | - |  481.33 | 1.43 |
+| MobileViTv3_x0_75  | 0.7626 | 0.9308 | 0.7655 | - | 1064.48 | 3.00 |
+| MobileViTv3_x1_0   | 0.7838 | 0.9421 | 0.7864 | - | 1875.96 | 5.14 |
+
+**备注：** PaddleClas 所提供的该系列模型的预训练模型权重，均是基于其官方提供的权重转得。
+
+<a name="2"></a>  
+
+## 2. 模型快速体验
+
+安装 paddlepaddle 和 paddleclas 即可快速对图片进行预测，体验方法可以参考[ResNet50 模型快速体验](./ResNet.md#2)。
+
+<a name="3"></a>
+
+## 3. 模型训练、评估和预测
+
+此部分内容包括训练环境配置、ImageNet数据的准备、该模型在 ImageNet 上的训练、评估、预测等内容。在 `ppcls/configs/ImageNet/MobileViTv3/` 中提供了该模型的训练配置，启动训练方法可以参考：[ResNet50 模型训练、评估和预测](./ResNet.md#3-模型训练评估和预测)。
+
+**备注：** 由于 MobileViT 系列模型默认使用的 GPU 数量为 8 个，所以在训练时，需要指定8个GPU，如`python3 -m paddle.distributed.launch --gpus="0,1,2,3,4,5,6,7" tools/train.py -c xxx.yaml`, 如果使用 4 个 GPU 训练，默认学习率需要减小一半，精度可能有损。
+
+<a name="4"></a>
+
+## 4. 模型推理部署
+
+<a name="4.1"></a>
+
+### 4.1 推理模型准备
+
+Paddle Inference 是飞桨的原生推理库， 作用于服务器端和云端，提供高性能的推理能力。相比于直接基于预训练模型进行预测，Paddle Inference可使用 MKLDNN、CUDNN、TensorRT 进行预测加速，从而实现更优的推理性能。更多关于Paddle Inference推理引擎的介绍，可以参考[Paddle Inference官网教程](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/infer/inference/inference_cn.html)。
+
+Inference 的获取可以参考 [ResNet50 推理模型准备](./ResNet.md#4.1) 。
+
+<a name="4.2"></a>
+
+### 4.2 基于 Python 预测引擎推理
+
+PaddleClas 提供了基于 python 预测引擎推理的示例。您可以参考[ResNet50 基于 Python 预测引擎推理](./ResNet.md#4.2) 完成模型的推理预测。
+
+<a name="4.3"></a>
+
+### 4.3 基于 C++ 预测引擎推理
+
+PaddleClas 提供了基于 C++ 预测引擎推理的示例，您可以参考[服务器端 C++ 预测](../../deployment/image_classification/cpp/linux.md)来完成相应的推理部署。如果您使用的是 Windows 平台，可以参考[基于 Visual Studio 2019 Community CMake 编译指南](../../deployment/image_classification/cpp/windows.md)完成相应的预测库编译和模型预测工作。
+
+<a name="4.4"></a>
+
+### 4.4 服务化部署
+
+Paddle Serving 提供高性能、灵活易用的工业级在线推理服务。Paddle Serving 支持 RESTful、gRPC、bRPC 等多种协议，提供多种异构硬件和多种操作系统环境下推理解决方案。更多关于Paddle Serving 的介绍，可以参考[Paddle Serving 代码仓库](https://github.com/PaddlePaddle/Serving)。
+
+PaddleClas 提供了基于 Paddle Serving 来完成模型服务化部署的示例，您可以参考[模型服务化部署](../../deployment/image_classification/paddle_serving.md)来完成相应的部署工作。
+
+<a name="4.5"></a>
+
+### 4.5 端侧部署
+
+Paddle Lite 是一个高性能、轻量级、灵活性强且易于扩展的深度学习推理框架，定位于支持包括移动端、嵌入式以及服务器端在内的多硬件平台。更多关于 Paddle Lite 的介绍，可以参考[Paddle Lite 代码仓库](https://github.com/PaddlePaddle/Paddle-Lite)。
+
+PaddleClas 提供了基于 Paddle Lite 来完成模型端侧部署的示例，您可以参考[端侧部署](../../deployment/image_classification/paddle_lite.md)来完成相应的部署工作。
+
+<a name="4.6"></a>
+
+### 4.6 Paddle2ONNX 模型转换与预测
+
+Paddle2ONNX 支持将 PaddlePaddle 模型格式转化到 ONNX 模型格式。通过 ONNX 可以完成将 Paddle 模型到多种推理引擎的部署，包括TensorRT/OpenVINO/MNN/TNN/NCNN，以及其它对 ONNX 开源格式进行支持的推理引擎或硬件。更多关于 Paddle2ONNX 的介绍，可以参考[Paddle2ONNX 代码仓库](https://github.com/PaddlePaddle/Paddle2ONNX)。
+
+PaddleClas 提供了基于 Paddle2ONNX 来完成 inference 模型转换 ONNX 模型并作推理预测的示例，您可以参考[Paddle2ONNX 模型转换与预测](../../deployment/image_classification/paddle2onnx.md)来完成相应的部署工作。

--- a/docs/zh_CN/models/ImageNet1k/README.md
+++ b/docs/zh_CN/models/ImageNet1k/README.md
@@ -796,15 +796,24 @@ DeiT（Data-efficient Image Transformers）系列模型的精度、速度指标�
 
 <a name="MobileViT"></a>
 
-## MobileViT 系列 <sup>[[42](#ref42)]</sup>
+## MobileViT 系列 <sup>[[42](#ref42)][[51](#ref51)]</sup>
 
-关于 MobileViT 系列模型的精度、速度指标如下表所示，更多介绍可以参考：[MobileViT 系列模型文档](MobileViT.md)。
+关于 MobileViT 系列模型的精度、速度指标如下表所示，更多介绍可以参考：[MobileViT 系列模型文档](MobileViT.md), [MobileViTv3 系列模型文档](MobileViTv3.md)。
 
 | 模型       | Top-1 Acc | Top-5 Acc | time(ms)<br>bs=1 | time(ms)<br>bs=4 | time(ms)<br/>bs=8 | FLOPs(M) | Params(M) | 预训练模型下载地址                                               | inference模型下载地址                                      |
 | ---------- | --------- | --------- | ---------------- | ---------------- | -------- | --------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-|  MobileViT_XXS    | 0.6867 | 0.8878 | - | - | - | 337.24  |  1.28   | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileViT_XXS_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileViT_XXS_infer.tar) |
-|  MobileViT_XS    | 0.7454 | 0.9227 | - | - | - | 930.75  |  2.33   | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileViT_XS_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileViT_XS_infer.tar) |
-|  MobileViT_S    | 0.7814 | 0.9413 | - | - | - | 1849.35  |   5.59   | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileViT_S_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileViT_S_infer.tar) |
+|  MobileViT_XXS     | 0.6867 | 0.8878 | - | - | - |  337.24 | 1.28 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileViT_XXS_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileViT_XXS_infer.tar) |
+|  MobileViT_XS      | 0.7454 | 0.9227 | - | - | - |  930.75 | 2.33 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileViT_XS_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileViT_XS_infer.tar) |
+|  MobileViT_S       | 0.7814 | 0.9413 | - | - | - | 1849.35 | 5.59 | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/MobileViT_S_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/MobileViT_S_infer.tar) |
+| MobileViTv3_XXS    | 0.7087 | 0.8976 | - | - | - |  289.02 | 1.25 | [下载链接]() | [下载链接]() |
+| MobileViTv3_XS     | 0.7663 | 0.9332 | - | - | - |  926.98 | 2.49 | [下载链接]() | [下载链接]() |
+| MobileViTv3_S      | 0.7928 | 0.9454 | - | - | - | 1841.39 | 5.76 | [下载链接]() | [下载链接]() |
+| MobileViTv3_XXS_L2 | 0.7028 | 0.8942 | - | - | - |  256.97 | 1.15 | [下载链接]() | [下载链接]() |
+| MobileViTv3_XS_L2  | 0.7607 | 0.9300 | - | - | - |  852.82 | 2.26 | [下载链接]() | [下载链接]() |
+| MobileViTv3_S_L2   | 0.7907 | 0.9440 | - | - | - | 1651.96 | 5.17 | [下载链接]() | [下载链接]() |
+| MobileViTv3_x0_5   | 0.7200 | 0.9083 | - | - | - |  481.33 | 1.43 | [下载链接]() | [下载链接]() |
+| MobileViTv3_x0_75  | 0.7626 | 0.9308 | - | - | - | 1064.48 | 3.00 | [下载链接]() | [下载链接]() |
+| MobileViTv3_x1_0   | 0.7838 | 0.9421 | - | - | - | 1875.96 | 5.14 | [下载链接]() | [下载链接]() |
 
 <a name='reference'></a>
 
@@ -910,3 +919,5 @@ TRANSFORMERS FOR IMAGE RECOGNITION AT SCALE.
 <a name="ref49">[49]</a>Mingyuan Mao, Renrui Zhang, Honghui Zheng, Peng Gao, Teli Ma, Yan Peng, Errui Ding, Baochang Zhang, Shumin Han. Dual-stream Network for Visual Recognition.
 
 <a name="ref50">[50]</a>Ze Liu, Han Hu, Yutong Lin, Zhuliang Yao, Zhenda Xie, Yixuan Wei, Jia Ning, Yue Cao, Zheng Zhang, Li Dong, Furu Wei, Baining Guo. Swin Transformer V2: Scaling Up Capacity and Resolution
+
+<a name="ref50">[51]</a>Wadekar, Shakti N. and Chaurasia, Abhishek. MobileViTv3: Mobile-Friendly Vision Transformer with Simple and Effective Fusion of Local, Global and Input Features

--- a/ppcls/arch/backbone/__init__.py
+++ b/ppcls/arch/backbone/__init__.py
@@ -78,6 +78,7 @@ from .model_zoo.cae import cae_base_patch16_224, cae_large_patch16_224
 from .model_zoo.cvt import CvT_13_224, CvT_13_384, CvT_21_224, CvT_21_384, CvT_W24_384
 from .model_zoo.micronet import MicroNet_M0, MicroNet_M1, MicroNet_M2, MicroNet_M3
 from .model_zoo.mobilenext import MobileNeXt_x0_35, MobileNeXt_x0_5, MobileNeXt_x0_75, MobileNeXt_x1_0, MobileNeXt_x1_4
+from .model_zoo.mobilevit_v3 import MobileViTv3_XXS, MobileViTv3_XS, MobileViTv3_S, MobileViTv3_x0_5, MobileViTv3_x0_75, MobileViTv3_x1_0
 
 from .variant_models.resnet_variant import ResNet50_last_stage_stride1
 from .variant_models.resnet_variant import ResNet50_adaptive_max_pool2d

--- a/ppcls/arch/backbone/__init__.py
+++ b/ppcls/arch/backbone/__init__.py
@@ -78,7 +78,7 @@ from .model_zoo.cae import cae_base_patch16_224, cae_large_patch16_224
 from .model_zoo.cvt import CvT_13_224, CvT_13_384, CvT_21_224, CvT_21_384, CvT_W24_384
 from .model_zoo.micronet import MicroNet_M0, MicroNet_M1, MicroNet_M2, MicroNet_M3
 from .model_zoo.mobilenext import MobileNeXt_x0_35, MobileNeXt_x0_5, MobileNeXt_x0_75, MobileNeXt_x1_0, MobileNeXt_x1_4
-from .model_zoo.mobilevit_v3 import MobileViTv3_XXS, MobileViTv3_XS, MobileViTv3_S, MobileViTv3_x0_5, MobileViTv3_x0_75, MobileViTv3_x1_0
+from .model_zoo.mobilevit_v3 import MobileViTv3_XXS, MobileViTv3_XS, MobileViTv3_S, MobileViTv3_XXS_L2, MobileViTv3_XS_L2, MobileViTv3_S_L2, MobileViTv3_x0_5, MobileViTv3_x0_75, MobileViTv3_x1_0
 
 from .variant_models.resnet_variant import ResNet50_last_stage_stride1
 from .variant_models.resnet_variant import ResNet50_adaptive_max_pool2d

--- a/ppcls/arch/backbone/model_zoo/mobilevit_v3.py
+++ b/ppcls/arch/backbone/model_zoo/mobilevit_v3.py
@@ -1,0 +1,1211 @@
+# copyright (c) 2023 PaddlePaddle Authors. All Rights Reserve.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Code was based on https://github.com/micronDLA/MobileViTv3/blob/main/MobileViTv3-v1/cvnets/models/classification/mobilevit.py
+# reference: https://arxiv.org/abs/2209.15159
+
+import math
+from functools import partial
+from typing import Dict, Optional, Tuple, Union
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+
+from ....utils.save_load import load_dygraph_pretrain, load_dygraph_pretrain_from_url
+
+MODEL_URLS = {
+    "MobileViTv3_XXS": "",
+    "MobileViTv3_XS": "",
+    "MobileViTv3_S": "",
+    "MobileViTv3_x0_5": "",
+    "MobileViTv3_x0_75": "",
+    "MobileViTv3_x1_0": "",
+}
+
+layer_norm_2d = partial(nn.GroupNorm, num_groups=1)
+
+
+def make_divisible(v, divisor=8, min_value=None):
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+class InvertedResidual(nn.Layer):
+    """
+    Inverted residual block (MobileNetv2): https://arxiv.org/abs/1801.04381
+    """
+
+    def __init__(self,
+                 in_channels: int,
+                 out_channels: int,
+                 stride: int,
+                 expand_ratio: Union[int, float],
+                 dilation: int=1) -> None:
+        assert stride in [1, 2]
+        super(InvertedResidual, self).__init__()
+        self.stride = stride
+
+        hidden_dim = make_divisible(int(round(in_channels * expand_ratio)), 8)
+        self.use_res_connect = self.stride == 1 and in_channels == out_channels
+
+        block = nn.Sequential()
+        if expand_ratio != 1:
+            block.add_sublayer(
+                name="exp_1x1",
+                sublayer=nn.Sequential(
+                    ('conv', nn.Conv2D(
+                        in_channels, hidden_dim, 1, bias_attr=False)),
+                    ('norm', nn.BatchNorm2D(hidden_dim)), ('act', nn.Silu())))
+
+        block.add_sublayer(
+            name="conv_3x3",
+            sublayer=nn.Sequential(
+                ('conv', nn.Conv2D(
+                    hidden_dim,
+                    hidden_dim,
+                    3,
+                    bias_attr=False,
+                    stride=stride,
+                    padding=dilation,
+                    dilation=dilation,
+                    groups=hidden_dim)), ('norm', nn.BatchNorm2D(hidden_dim)),
+                ('act', nn.Silu())))
+
+        block.add_sublayer(
+            name="red_1x1",
+            sublayer=nn.Sequential(
+                ('conv', nn.Conv2D(
+                    hidden_dim, out_channels, 1, bias_attr=False)),
+                ('norm', nn.BatchNorm2D(out_channels))))
+
+        self.block = block
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.exp = expand_ratio
+        self.dilation = dilation
+
+    def forward(self, x, *args, **kwargs):
+        if self.use_res_connect:
+            return x + self.block(x)
+        else:
+            return self.block(x)
+
+
+class MultiHeadAttention(nn.Layer):
+    def __init__(self,
+                 dim,
+                 num_heads=8,
+                 qkv_bias=False,
+                 qk_scale=None,
+                 attn_drop=0.):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+
+        self.qkv_proj = nn.Linear(dim, dim * 3, bias_attr=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.out_proj = nn.Linear(dim, dim, bias_attr=qkv_bias)
+
+    def forward(self, x):
+        # B = paddle.shape(x)[0]
+        N, C = x.shape[1:]
+        qkv = self.qkv_proj(x).reshape((-1, N, 3, self.num_heads,
+                                        C // self.num_heads)).transpose(
+                                            (2, 0, 3, 1, 4))
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        attn = (q.matmul(k.transpose((0, 1, 3, 2)))) * self.scale
+        attn = nn.functional.softmax(attn, axis=-1)
+        attn = self.attn_drop(attn)
+
+        x = (attn.matmul(v)).transpose((0, 2, 1, 3)).reshape((-1, N, C))
+        x = self.out_proj(x)
+        return x
+
+
+class TransformerEncoder(nn.Layer):
+    """
+        This class defines the Transformer encoder (pre-norm) as described in "Attention is all you need" paper
+            https://arxiv.org/abs/1706.03762
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 ffn_latent_dim: int,
+                 num_heads: Optional[int]=8,
+                 attn_dropout: Optional[float]=0.0,
+                 dropout: Optional[float]=0.1,
+                 ffn_dropout: Optional[float]=0.0,
+                 transformer_norm_layer: nn.Layer=nn.LayerNorm):
+        super(TransformerEncoder, self).__init__()
+
+        self.pre_norm_mha = nn.Sequential(
+            transformer_norm_layer(embed_dim),
+            MultiHeadAttention(
+                embed_dim, num_heads, attn_drop=attn_dropout, qkv_bias=True),
+            nn.Dropout(p=dropout))
+
+        self.pre_norm_ffn = nn.Sequential(
+            transformer_norm_layer(embed_dim),
+            nn.Linear(embed_dim, ffn_latent_dim),
+            nn.Silu(),
+            nn.Dropout(p=ffn_dropout),
+            nn.Linear(ffn_latent_dim, embed_dim),
+            nn.Dropout(p=dropout))
+        self.embed_dim = embed_dim
+        self.ffn_dim = ffn_latent_dim
+        self.ffn_dropout = ffn_dropout
+
+    def forward(self, x):
+        # Multi-head attention
+        x = x + self.pre_norm_mha(x)
+
+        # Feed forward network
+        x = x + self.pre_norm_ffn(x)
+        return x
+
+
+class MobileViTv3Block(nn.Layer):
+    """
+        MobileViTv3 block
+    """
+
+    def __init__(self,
+                 in_channels: int,
+                 transformer_dim: int,
+                 ffn_dim: int,
+                 n_transformer_blocks: Optional[int]=2,
+                 head_dim: Optional[int]=32,
+                 attn_dropout: Optional[float]=0.1,
+                 dropout: Optional[int]=0.1,
+                 ffn_dropout: Optional[int]=0.1,
+                 patch_h: Optional[int]=8,
+                 patch_w: Optional[int]=8,
+                 transformer_norm_layer: nn.Layer=nn.LayerNorm,
+                 conv_ksize: Optional[int]=3,
+                 dilation: Optional[int]=1,
+                 var_ffn: Optional[bool]=False,
+                 no_fusion: Optional[bool]=False):
+
+        # For MobileViTv3: Normal 3x3 convolution --> Depthwise 3x3 convolution
+        padding = (conv_ksize - 1) // 2 * dilation
+        conv_3x3_in = nn.Sequential(
+            ('conv', nn.Conv2D(
+                in_channels,
+                in_channels,
+                conv_ksize,
+                bias_attr=False,
+                padding=padding,
+                dilation=dilation,
+                groups=in_channels)), ('norm', nn.BatchNorm2D(in_channels)),
+            ('act', nn.Silu()))
+        conv_1x1_in = nn.Sequential(('conv', nn.Conv2D(
+            in_channels, transformer_dim, 1, bias_attr=False)))
+
+        conv_1x1_out = nn.Sequential(
+            ('conv', nn.Conv2D(
+                transformer_dim, in_channels, 1, bias_attr=False)),
+            ('norm', nn.BatchNorm2D(in_channels)), ('act', nn.Silu()))
+        conv_3x3_out = None
+
+        # For MobileViTv3: input+global --> local+global
+        if not no_fusion:
+            #input_ch = tr_dim + in_ch
+            conv_3x3_out = nn.Sequential(
+                ('conv', nn.Conv2D(
+                    transformer_dim + in_channels,
+                    in_channels,
+                    1,
+                    bias_attr=False)), ('norm', nn.BatchNorm2D(in_channels)),
+                ('act', nn.Silu()))
+
+        super().__init__()
+        self.local_rep = nn.Sequential()
+        self.local_rep.add_sublayer(name="conv_3x3", sublayer=conv_3x3_in)
+        self.local_rep.add_sublayer(name="conv_1x1", sublayer=conv_1x1_in)
+
+        assert transformer_dim % head_dim == 0
+        num_heads = transformer_dim // head_dim
+
+        ffn_dims = [ffn_dim] * n_transformer_blocks
+
+        global_rep = [
+            TransformerEncoder(
+                embed_dim=transformer_dim,
+                ffn_latent_dim=ffn_dims[block_idx],
+                num_heads=num_heads,
+                attn_dropout=attn_dropout,
+                dropout=dropout,
+                ffn_dropout=ffn_dropout,
+                transformer_norm_layer=transformer_norm_layer)
+            for block_idx in range(n_transformer_blocks)
+        ]
+        global_rep.append(transformer_norm_layer(transformer_dim))
+        self.global_rep = nn.Sequential(*global_rep)
+
+        self.conv_proj = conv_1x1_out
+
+        self.fusion = conv_3x3_out
+
+        self.patch_h = patch_h
+        self.patch_w = patch_w
+        self.patch_area = self.patch_w * self.patch_h
+
+        self.cnn_in_dim = in_channels
+        self.cnn_out_dim = transformer_dim
+        self.n_heads = num_heads
+        self.ffn_dim = ffn_dim
+        self.dropout = dropout
+        self.attn_dropout = attn_dropout
+        self.ffn_dropout = ffn_dropout
+        self.dilation = dilation
+        self.ffn_max_dim = ffn_dims[0]
+        self.ffn_min_dim = ffn_dims[-1]
+        self.var_ffn = var_ffn
+        self.n_blocks = n_transformer_blocks
+        self.conv_ksize = conv_ksize
+
+    def unfolding(self, feature_map):
+        patch_w, patch_h = self.patch_w, self.patch_h
+        patch_area = int(patch_w * patch_h)
+        batch_size, in_channels, orig_h, orig_w = feature_map.shape
+
+        new_h = int(math.ceil(orig_h / self.patch_h) * self.patch_h)
+        new_w = int(math.ceil(orig_w / self.patch_w) * self.patch_w)
+
+        interpolate = False
+        if new_w != orig_w or new_h != orig_h:
+            # Note: Padding can be done, but then it needs to be handled in attention function.
+            feature_map = F.interpolate(
+                feature_map,
+                size=(new_h, new_w),
+                mode="bilinear",
+                align_corners=False)
+            interpolate = True
+
+        # number of patches along width and height
+        num_patch_w = new_w // patch_w  # n_w
+        num_patch_h = new_h // patch_h  # n_h
+        num_patches = num_patch_h * num_patch_w  # N
+
+        # [B, C, H, W] --> [B * C * n_h, p_h, n_w, p_w]
+        reshaped_fm = feature_map.reshape([
+            batch_size * in_channels * num_patch_h, patch_h, num_patch_w,
+            patch_w
+        ])
+        # [B * C * n_h, p_h, n_w, p_w] --> [B * C * n_h, n_w, p_h, p_w]
+        transposed_fm = reshaped_fm.transpose([0, 2, 1, 3])
+        # [B * C * n_h, n_w, p_h, p_w] --> [B, C, N, P] where P = p_h * p_w and N = n_h * n_w
+        reshaped_fm = transposed_fm.reshape(
+            [batch_size, in_channels, num_patches, patch_area])
+        # [B, C, N, P] --> [B, P, N, C]
+        transposed_fm = reshaped_fm.transpose([0, 3, 2, 1])
+        # [B, P, N, C] --> [BP, N, C]
+        patches = transposed_fm.reshape(
+            [batch_size * patch_area, num_patches, -1])
+
+        info_dict = {
+            "orig_size": (orig_h, orig_w),
+            "batch_size": batch_size,
+            "interpolate": interpolate,
+            "total_patches": num_patches,
+            "num_patches_w": num_patch_w,
+            "num_patches_h": num_patch_h
+        }
+
+        return patches, info_dict
+
+    def folding(self, patches, info_dict):
+        n_dim = patches.dim()
+        assert n_dim == 3, "Tensor should be of shape BPxNxC. Got: {}".format(
+            patches.shape)
+        # [BP, N, C] --> [B, P, N, C]
+        patches = patches.reshape([
+            info_dict["batch_size"], self.patch_area,
+            info_dict["total_patches"], -1
+        ])
+
+        batch_size, pixels, num_patches, channels = patches.shape
+        num_patch_h = info_dict["num_patches_h"]
+        num_patch_w = info_dict["num_patches_w"]
+
+        # [B, P, N, C] --> [B, C, N, P]
+        patches = patches.transpose([0, 3, 2, 1])
+
+        # [B, C, N, P] --> [B*C*n_h, n_w, p_h, p_w]
+        feature_map = patches.reshape([
+            batch_size * channels * num_patch_h, num_patch_w, self.patch_h,
+            self.patch_w
+        ])
+        # [B*C*n_h, n_w, p_h, p_w] --> [B*C*n_h, p_h, n_w, p_w]
+        feature_map = feature_map.transpose([0, 2, 1, 3])
+        # [B*C*n_h, p_h, n_w, p_w] --> [B, C, H, W]
+        feature_map = feature_map.reshape([
+            batch_size, channels, num_patch_h * self.patch_h,
+            num_patch_w * self.patch_w
+        ])
+        if info_dict["interpolate"]:
+            feature_map = F.interpolate(
+                feature_map,
+                size=info_dict["orig_size"],
+                mode="bilinear",
+                align_corners=False)
+        return feature_map
+
+    def forward(self, x):
+        res = x
+
+        # For MobileViTv3: Normal 3x3 convolution --> Depthwise 3x3 convolution
+        fm_conv = self.local_rep(x)
+
+        # convert feature map to patches
+        patches, info_dict = self.unfolding(fm_conv)
+
+        # learn global representations
+        patches = self.global_rep(patches)
+
+        # [B x Patch x Patches x C] --> [B x C x Patches x Patch]
+        fm = self.folding(patches=patches, info_dict=info_dict)
+
+        fm = self.conv_proj(fm)
+
+        if self.fusion is not None:
+            # For MobileViTv3: input+global --> local+global
+            fm = self.fusion(paddle.concat((fm_conv, fm), axis=1))
+
+        # For MobileViTv3: Skip connection
+        fm = fm + res
+
+        return fm
+
+
+class LinearSelfAttention(nn.Layer):
+    def __init__(self, embed_dim, attn_dropout=0.0, bias=True):
+        super().__init__()
+        self.qkv_proj = nn.Conv2D(
+            embed_dim, 1 + (2 * embed_dim), 1, bias_attr=bias)
+        self.attn_dropout = nn.Dropout(p=attn_dropout)
+        self.out_proj = nn.Conv2D(embed_dim, embed_dim, 1, bias_attr=bias)
+
+    def forward(self, x):
+        # [B, C, P, N] --> [B, h + 2d, P, N]
+        qkv = self.qkv_proj(x)
+
+        # Project x into query, key and value
+        # Query --> [B, 1, P, N]
+        # value, key --> [B, d, P, N]
+        query, key, value = paddle.split(
+            qkv, [1, self.embed_dim, self.embed_dim], axis=1)
+
+        # apply softmax along N dimension
+        context_scores = F.softmax(query, axis=-1)
+        # Uncomment below line to visualize context scores
+        # self.visualize_context_scores(context_scores=context_scores)
+        context_scores = self.attn_dropout(context_scores)
+
+        # Compute context vector
+        # [B, d, P, N] x [B, 1, P, N] -> [B, d, P, N]
+        context_vector = key * context_scores
+        # [B, d, P, N] --> [B, d, P, 1]
+        context_vector = paddle.sum(context_vector, axis=-1, keepdim=True)
+
+        # combine context vector with values
+        # [B, d, P, N] * [B, d, P, 1] --> [B, d, P, N]
+        out = F.relu(value) * context_vector.expand_as(value)
+        out = self.out_proj(out)
+        return out
+
+
+class LinearAttnFFN(nn.Layer):
+    def __init__(self,
+                 embed_dim: int,
+                 ffn_latent_dim: int,
+                 attn_dropout: Optional[float]=0.0,
+                 dropout: Optional[float]=0.1,
+                 ffn_dropout: Optional[float]=0.0,
+                 norm_layer: Optional[str]=layer_norm_2d) -> None:
+        super().__init__()
+        attn_unit = LinearSelfAttention(
+            embed_dim=embed_dim, attn_dropout=attn_dropout, bias=True)
+
+        self.pre_norm_attn = nn.Sequential(
+            norm_layer(num_channels=embed_dim),
+            attn_unit,
+            nn.Dropout(p=dropout))
+
+        self.pre_norm_ffn = nn.Sequential(
+            norm_layer(num_channels=embed_dim),
+            nn.Conv2D(embed_dim, ffn_latent_dim, 1),
+            nn.Silu(),
+            nn.Dropout(p=ffn_dropout),
+            nn.Conv2D(ffn_latent_dim, embed_dim, 1),
+            nn.Dropout(p=dropout))
+
+    def forward(self, x):
+        # self-attention
+        x = x + self.pre_norm_attn(x)
+        # Feed forward network
+        x = x + self.pre_norm_ffn(x)
+        return x
+
+
+class MobileViTv3Block_v2(nn.Layer):
+    """
+    This class defines the `MobileViTv3 block`
+    """
+
+    def __init__(self,
+                 in_channels: int,
+                 attn_unit_dim: int,
+                 ffn_multiplier: float=2.0,
+                 n_attn_blocks: Optional[int]=2,
+                 attn_dropout: Optional[float]=0.0,
+                 dropout: Optional[float]=0.0,
+                 ffn_dropout: Optional[float]=0.0,
+                 patch_h: Optional[int]=8,
+                 patch_w: Optional[int]=8,
+                 conv_ksize: Optional[int]=3,
+                 dilation: Optional[int]=1,
+                 attn_norm_layer: Optional[str]=layer_norm_2d):
+        cnn_out_dim = attn_unit_dim
+
+        padding = (conv_ksize - 1) // 2 * dilation
+        conv_3x3_in = nn.Sequential(
+            ('conv', nn.Conv2D(
+                in_channels,
+                in_channels,
+                conv_ksize,
+                bias_attr=False,
+                padding=padding,
+                dilation=dilation,
+                groups=in_channels)), ('norm', nn.BatchNorm2D(in_channels)),
+            ('act', nn.Silu()))
+        conv_1x1_in = nn.Sequential(('conv', nn.Conv2D(
+            in_channels, cnn_out_dim, 1, bias_attr=False)))
+
+        super().__init__()
+        self.local_rep = nn.Sequential(conv_3x3_in, conv_1x1_in)
+
+        self.global_rep, attn_unit_dim = self._build_attn_layer(
+            d_model=attn_unit_dim,
+            ffn_mult=ffn_multiplier,
+            n_layers=n_attn_blocks,
+            attn_dropout=attn_dropout,
+            dropout=dropout,
+            ffn_dropout=ffn_dropout,
+            attn_norm_layer=attn_norm_layer)
+
+        # MobileViTv3: input changed from just global to local+global
+        self.conv_proj = nn.Sequential(
+            ('conv', nn.Conv2D(
+                2 * cnn_out_dim, in_channels, 1, bias_attr=False)),
+            ('norm', nn.BatchNorm2D(in_channels)))
+
+        self.patch_h = patch_h
+        self.patch_w = patch_w
+
+    def _build_attn_layer(self,
+                          d_model: int,
+                          ffn_mult: float,
+                          n_layers: int,
+                          attn_dropout: float,
+                          dropout: float,
+                          ffn_dropout: float,
+                          attn_norm_layer: nn.Layer):
+
+        # ensure that dims are multiple of 16
+        ffn_dims = [ffn_mult * d_model // 16 * 16] * n_layers
+
+        global_rep = [
+            LinearAttnFFN(
+                embed_dim=d_model,
+                ffn_latent_dim=ffn_dims[block_idx],
+                attn_dropout=attn_dropout,
+                dropout=dropout,
+                ffn_dropout=ffn_dropout,
+                norm_layer=attn_norm_layer) for block_idx in range(n_layers)
+        ]
+        global_rep.append(attn_norm_layer(num_channels=d_model))
+
+        return nn.Sequential(*global_rep), d_model
+
+    def unfolding(self, feature_map):
+        batch_size, in_channels, img_h, img_w = feature_map.shape
+
+        # [B, C, H, W] --> [B, C, P, N]
+        patches = F.unfold(
+            feature_map,
+            kernel_sizes=(self.patch_h, self.patch_w),
+            stride=(self.patch_h, self.patch_w))
+        patches = patches.reshape(
+            [batch_size, in_channels, self.patch_h * self.patch_w, -1])
+
+        return patches, (img_h, img_w)
+
+    def folding(self, patches, output_size: Tuple[int, int]):
+        batch_size, in_dim, patch_size, n_patches = patches.shape
+
+        # [B, C, P, N]
+        patches = patches.reshape([batch_size, in_dim * patch_size, n_patches])
+
+        feature_map = F.fold(
+            patches,
+            output_sizes=output_size,
+            kernel_sizes=(self.patch_h, self.patch_w),
+            stride=(self.patch_h, self.patch_w))
+
+        return feature_map
+
+    def forward(self, x):
+        fm_conv = self.local_rep(x)
+
+        # convert feature map to patches
+        patches, output_size = self.unfolding(fm_conv)
+
+        # learn global representations on all patches
+        patches = self.global_rep(patches)
+
+        # [B x Patch x Patches x C] --> [B x C x Patches x Patch]
+        fm = self.folding(patches=patches, output_size=output_size)
+
+        # MobileViTv3: local+global instead of only global
+        fm = self.conv_proj(paddle.concat((fm, fm_conv), axis=1))
+
+        # MobileViTv3: skip connection
+        fm = fm + x
+
+        return fm
+
+
+class MobileViTv3(nn.Layer):
+    """
+        MobileViTv3:
+    """
+
+    def __init__(self,
+                 mobilevit_config: Dict,
+                 dropout=0.1,
+                 class_num=1000,
+                 classifier_dropout=0.1,
+                 output_stride=None,
+                 mobilevit_v2_based=False):
+        super().__init__()
+        self.round_nearest = 8
+        self.dilation = 1
+        self.dropout = dropout
+        self.mobilevit_v2_based = mobilevit_v2_based
+
+        dilate_l4 = dilate_l5 = False
+        if output_stride == 8:
+            dilate_l4 = True
+            dilate_l5 = True
+        elif output_stride == 16:
+            dilate_l5 = True
+
+        # store model configuration in a dictionary
+        in_channels = mobilevit_config["layer0"]["img_channels"]
+        out_channels = mobilevit_config["layer0"]["out_channels"]
+        self.conv_1 = nn.Sequential(
+            ('conv', nn.Conv2D(
+                in_channels,
+                out_channels,
+                3,
+                bias_attr=False,
+                stride=2,
+                padding=1)), ('norm', nn.BatchNorm2D(out_channels)),
+            ('act', nn.Silu()))
+
+        in_channels = out_channels
+        self.layer_1, out_channels = self._make_layer(
+            input_channel=in_channels, cfg=mobilevit_config["layer1"])
+
+        in_channels = out_channels
+        self.layer_2, out_channels = self._make_layer(
+            input_channel=in_channels, cfg=mobilevit_config["layer2"])
+
+        in_channels = out_channels
+        self.layer_3, out_channels = self._make_layer(
+            input_channel=in_channels, cfg=mobilevit_config["layer3"])
+
+        in_channels = out_channels
+        self.layer_4, out_channels = self._make_layer(
+            input_channel=in_channels,
+            cfg=mobilevit_config["layer4"],
+            dilate=dilate_l4)
+
+        in_channels = out_channels
+        self.layer_5, out_channels = self._make_layer(
+            input_channel=in_channels,
+            cfg=mobilevit_config["layer5"],
+            dilate=dilate_l5)
+
+        in_channels = out_channels
+        exp_channels = min(mobilevit_config["last_layer_exp_factor"] *
+                           in_channels, 960)
+        if self.mobilevit_v2_based:
+            self.conv_1x1_exp = nn.Identity()
+        else:
+            self.conv_1x1_exp = nn.Sequential(
+                ('conv', nn.Conv2D(
+                    in_channels, exp_channels, 1, bias_attr=False)),
+                ('norm', nn.BatchNorm2D(exp_channels)), ('act', nn.Silu()))
+
+        self.classifier = nn.Sequential()
+        self.classifier.add_sublayer(
+            name="global_pool",
+            sublayer=nn.Sequential(nn.AdaptiveAvgPool2D(1), nn.Flatten()))
+        if 0.0 < classifier_dropout < 1.0:
+            self.classifier.add_sublayer(
+                name="dropout", sublayer=nn.Dropout(p=classifier_dropout))
+        self.classifier.add_sublayer(
+            name="fc", sublayer=nn.Linear(exp_channels, class_num))
+
+        # weight initialization
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, nn.Conv2D):
+            fan_out = m.weight.shape[0] * m.weight.shape[2] * m.weight.shape[3]
+            nn.initializer.KaimingNormal(fan_in=fan_out)(m.weight)
+            if m.bias is not None:
+                nn.initializer.Constant(0)(m.bias)
+        elif isinstance(m, nn.BatchNorm2D):
+            nn.initializer.Constant(1)(m.weight)
+            nn.initializer.Constant(0)(m.bias)
+        elif isinstance(m, nn.Linear):
+            nn.initializer.TruncatedNormal(std=.02)(m.weight)
+            if m.bias is not None:
+                nn.initializer.Constant(0)(m.bias)
+
+    def _make_layer(self, input_channel, cfg, dilate=False):
+        block_type = cfg.get("block_type", "mobilevit")
+        if block_type.lower() == "mobilevit":
+            return self._make_mit_layer(
+                input_channel=input_channel, cfg=cfg, dilate=dilate)
+        else:
+            return self._make_mobilenet_layer(
+                input_channel=input_channel, cfg=cfg)
+
+    def _make_mit_layer(self, input_channel, cfg, dilate=False):
+        prev_dilation = self.dilation
+        block = []
+        stride = cfg.get("stride", 1)
+
+        if stride == 2:
+            if dilate:
+                self.dilation *= 2
+                stride = 1
+
+            layer = InvertedResidual(
+                in_channels=input_channel,
+                out_channels=cfg.get("out_channels"),
+                stride=stride,
+                expand_ratio=cfg.get("mv_expand_ratio", 4),
+                dilation=prev_dilation)
+
+            block.append(layer)
+            input_channel = cfg.get("out_channels")
+
+        if self.mobilevit_v2_based:
+            block.append(
+                MobileViTv3Block_v2(
+                    in_channels=input_channel,
+                    attn_unit_dim=cfg["attn_unit_dim"],
+                    ffn_multiplier=cfg.get("ffn_multiplier"),
+                    n_attn_blocks=cfg.get("attn_blocks", 1),
+                    ffn_dropout=0.,
+                    attn_dropout=0.,
+                    dilation=self.dilation,
+                    patch_h=cfg.get("patch_h", 2),
+                    patch_w=cfg.get("patch_w", 2)))
+        else:
+            head_dim = cfg.get("head_dim", 32)
+            transformer_dim = cfg["transformer_channels"]
+            ffn_dim = cfg.get("ffn_dim")
+            if head_dim is None:
+                num_heads = cfg.get("num_heads", 4)
+                if num_heads is None:
+                    num_heads = 4
+                head_dim = transformer_dim // num_heads
+
+            assert transformer_dim % head_dim == 0, (
+                "Transformer input dimension should be divisible by head dimension. "
+                "Got {} and {}.".format(transformer_dim, head_dim))
+
+            block.append(
+                MobileViTv3Block(
+                    in_channels=input_channel,
+                    transformer_dim=transformer_dim,
+                    ffn_dim=ffn_dim,
+                    n_transformer_blocks=cfg.get("transformer_blocks", 1),
+                    patch_h=cfg.get("patch_h", 2),
+                    patch_w=cfg.get("patch_w", 2),
+                    dropout=self.dropout,
+                    ffn_dropout=0.,
+                    attn_dropout=0.,
+                    head_dim=head_dim))
+
+        return nn.Sequential(*block), input_channel
+
+    def _make_mobilenet_layer(self, input_channel, cfg):
+        output_channels = cfg.get("out_channels")
+        num_blocks = cfg.get("num_blocks", 2)
+        expand_ratio = cfg.get("expand_ratio", 4)
+        block = []
+
+        for i in range(num_blocks):
+            stride = cfg.get("stride", 1) if i == 0 else 1
+
+            layer = InvertedResidual(
+                in_channels=input_channel,
+                out_channels=output_channels,
+                stride=stride,
+                expand_ratio=expand_ratio)
+            block.append(layer)
+            input_channel = output_channels
+        return nn.Sequential(*block), input_channel
+
+    def extract_features(self, x):
+        x = self.conv_1(x)
+        x = self.layer_1(x)
+        x = self.layer_2(x)
+        x = self.layer_3(x)
+
+        x = self.layer_4(x)
+        x = self.layer_5(x)
+        x = self.conv_1x1_exp(x)
+        return x
+
+    def forward(self, x):
+        x = self.extract_features(x)
+        x = self.classifier(x)
+        return x
+
+
+def _load_pretrained(pretrained, model, model_url, use_ssld=False):
+    if pretrained is False:
+        pass
+    elif pretrained is True:
+        load_dygraph_pretrain_from_url(model, model_url, use_ssld=use_ssld)
+    elif isinstance(pretrained, str):
+        load_dygraph_pretrain(model, pretrained)
+    else:
+        raise RuntimeError(
+            "pretrained type is not available. Please use `string` or `boolean` type."
+        )
+
+
+def MobileViTv3_S(pretrained=False, use_ssld=False, **kwargs):
+    mv2_exp_mult = 4
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 16,
+        },
+        "layer1": {
+            "out_channels": 32,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2"
+        },
+        "layer2": {
+            "out_channels": 64,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 3,
+            "stride": 2,
+            "block_type": "mv2"
+        },
+        "layer3": {  # 28x28
+            "out_channels": 128,
+            "transformer_channels": 144,
+            "ffn_dim": 288,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer4": {  # 14x14
+            "out_channels": 256,
+            "transformer_channels": 192,
+            "ffn_dim": 384,
+            "transformer_blocks": 4,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer5": {  # 7x7
+            "out_channels": 320,
+            "transformer_channels": 240,
+            "ffn_dim": 480,
+            "transformer_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "last_layer_exp_factor": 4
+    }
+
+    model = MobileViTv3(mobilevit_config, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_S"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_XS(pretrained=False, use_ssld=False, **kwargs):
+    mv2_exp_mult = 4
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 16,
+        },
+        "layer1": {
+            "out_channels": 32,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2"
+        },
+        "layer2": {
+            "out_channels": 48,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 3,
+            "stride": 2,
+            "block_type": "mv2"
+        },
+        "layer3": {  # 28x28
+            "out_channels": 96,
+            "transformer_channels": 96,
+            "ffn_dim": 192,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer4": {  # 14x14
+            "out_channels": 160,
+            "transformer_channels": 120,
+            "ffn_dim": 240,
+            "transformer_blocks": 4,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer5": {  # 7x7
+            "out_channels": 160,
+            "transformer_channels": 144,
+            "ffn_dim": 288,
+            "transformer_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "last_layer_exp_factor": 4
+    }
+
+    model = MobileViTv3(mobilevit_config, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_XS"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_XXS(pretrained=False, use_ssld=False, **kwargs):
+    mv2_exp_mult = 2
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 16,
+        },
+        "layer1": {
+            "out_channels": 16,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2"
+        },
+        "layer2": {
+            "out_channels": 24,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 3,
+            "stride": 2,
+            "block_type": "mv2"
+        },
+        "layer3": {  # 28x28
+            "out_channels": 64,
+            "transformer_channels": 64,
+            "ffn_dim": 128,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer4": {  # 14x14
+            "out_channels": 80,
+            "transformer_channels": 80,
+            "ffn_dim": 160,
+            "transformer_blocks": 4,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer5": {  # 7x7
+            "out_channels": 128,
+            "transformer_channels": 96,
+            "ffn_dim": 192,
+            "transformer_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "last_layer_exp_factor": 4
+    }
+
+    model = MobileViTv3(mobilevit_config, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_XXS"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_x1_0(pretrained=False, use_ssld=False, **kwargs):
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 32,
+        },
+        "layer1": {
+            "out_channels": 64,
+            "expand_ratio": 2,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2",
+        },
+        "layer2": {
+            "out_channels": 128,
+            "expand_ratio": 2,
+            "num_blocks": 2,
+            "stride": 2,
+            "block_type": "mv2",
+        },
+        "layer3": {  # 28x28
+            "out_channels": 256,
+            "attn_unit_dim": 128,
+            "ffn_multiplier": 2,
+            "attn_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "layer4": {  # 14x14
+            "out_channels": 384,
+            "attn_unit_dim": 192,
+            "ffn_multiplier": 2,
+            "attn_blocks": 4,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "layer5": {  # 7x7
+            "out_channels": 512,
+            "attn_unit_dim": 256,
+            "ffn_multiplier": 2,
+            "attn_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "last_layer_exp_factor": 4,
+    }
+
+    model = MobileViTv3(mobilevit_config, mobilevit_v2_based=True, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_x1_0"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_x0_75(pretrained=False, use_ssld=False, **kwargs):
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 24,
+        },
+        "layer1": {
+            "out_channels": 48,
+            "expand_ratio": 2,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2",
+        },
+        "layer2": {
+            "out_channels": 96,
+            "expand_ratio": 2,
+            "num_blocks": 2,
+            "stride": 2,
+            "block_type": "mv2",
+        },
+        "layer3": {  # 28x28
+            "out_channels": 192,
+            "attn_unit_dim": 96,
+            "ffn_multiplier": 2,
+            "attn_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "layer4": {  # 14x14
+            "out_channels": 288,
+            "attn_unit_dim": 144,
+            "ffn_multiplier": 2,
+            "attn_blocks": 4,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "layer5": {  # 7x7
+            "out_channels": 384,
+            "attn_unit_dim": 192,
+            "ffn_multiplier": 2,
+            "attn_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "last_layer_exp_factor": 4,
+    }
+
+    model = MobileViTv3(mobilevit_config, mobilevit_v2_based=True, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_x0_75"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_x0_5(pretrained=False, use_ssld=False, **kwargs):
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 16,
+        },
+        "layer1": {
+            "out_channels": 32,
+            "expand_ratio": 2,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2",
+        },
+        "layer2": {
+            "out_channels": 64,
+            "expand_ratio": 2,
+            "num_blocks": 2,
+            "stride": 2,
+            "block_type": "mv2",
+        },
+        "layer3": {  # 28x28
+            "out_channels": 128,
+            "attn_unit_dim": 64,
+            "ffn_multiplier": 2,
+            "attn_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "layer4": {  # 14x14
+            "out_channels": 192,
+            "attn_unit_dim": 96,
+            "ffn_multiplier": 2,
+            "attn_blocks": 4,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "layer5": {  # 7x7
+            "out_channels": 256,
+            "attn_unit_dim": 128,
+            "ffn_multiplier": 2,
+            "attn_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": 2,
+            "block_type": "mobilevit",
+        },
+        "last_layer_exp_factor": 4,
+    }
+
+    model = MobileViTv3(mobilevit_config, mobilevit_v2_based=True, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_x0_5"], use_ssld=use_ssld)
+    return model

--- a/ppcls/arch/backbone/model_zoo/mobilevit_v3.py
+++ b/ppcls/arch/backbone/model_zoo/mobilevit_v3.py
@@ -687,15 +687,25 @@ class MobileViTv3(nn.Layer):
 
     def _init_weights(self, m):
         if isinstance(m, nn.Conv2D):
+            fan_in = m.weight.shape[1] * m.weight.shape[2] * m.weight.shape[3]
             fan_out = m.weight.shape[0] * m.weight.shape[2] * m.weight.shape[3]
-            nn.initializer.KaimingNormal(fan_in=fan_out)(m.weight)
-            if m.bias is not None:
-                nn.initializer.Constant(0)(m.bias)
+            if self.mobilevit_v2_based:
+                bound = 1.0 / fan_in**0.5
+                nn.initializer.Uniform(-bound, bound)(m.weight)
+                if m.bias is not None:
+                    nn.initializer.Uniform(-bound, bound)(m.bias)
+            else:
+                nn.initializer.KaimingNormal(fan_in=fan_out)(m.weight)
+                if m.bias is not None:
+                    nn.initializer.Constant(0)(m.bias)
         elif isinstance(m, nn.BatchNorm2D):
             nn.initializer.Constant(1)(m.weight)
             nn.initializer.Constant(0)(m.bias)
         elif isinstance(m, nn.Linear):
-            nn.initializer.TruncatedNormal(std=.02)(m.weight)
+            if self.mobilevit_v2_based:
+                nn.initializer.XavierUniform()(m.weight)
+            else:
+                nn.initializer.TruncatedNormal(std=.02)(m.weight)
             if m.bias is not None:
                 nn.initializer.Constant(0)(m.bias)
 

--- a/ppcls/arch/backbone/model_zoo/mobilevit_v3.py
+++ b/ppcls/arch/backbone/model_zoo/mobilevit_v3.py
@@ -29,6 +29,9 @@ MODEL_URLS = {
     "MobileViTv3_XXS": "",
     "MobileViTv3_XS": "",
     "MobileViTv3_S": "",
+    "MobileViTv3_XXS_L2": "",
+    "MobileViTv3_XS_L2": "",
+    "MobileViTv3_S_L2": "",
     "MobileViTv3_x0_5": "",
     "MobileViTv3_x0_75": "",
     "MobileViTv3_x1_0": "",
@@ -319,7 +322,7 @@ class MobileViTv3Block(nn.Layer):
         transposed_fm = reshaped_fm.transpose([0, 3, 2, 1])
         # [B, P, N, C] --> [BP, N, C]
         patches = transposed_fm.reshape(
-            [batch_size * patch_area, num_patches, -1])
+            [batch_size * patch_area, num_patches, in_channels])
 
         info_dict = {
             "orig_size": (orig_h, orig_w),
@@ -339,7 +342,7 @@ class MobileViTv3Block(nn.Layer):
         # [BP, N, C] --> [B, P, N, C]
         patches = patches.reshape([
             info_dict["batch_size"], self.patch_area,
-            info_dict["total_patches"], -1
+            info_dict["total_patches"], patches.shape[2]
         ])
 
         batch_size, pixels, num_patches, channels = patches.shape
@@ -399,6 +402,7 @@ class MobileViTv3Block(nn.Layer):
 class LinearSelfAttention(nn.Layer):
     def __init__(self, embed_dim, attn_dropout=0.0, bias=True):
         super().__init__()
+        self.embed_dim = embed_dim
         self.qkv_proj = nn.Conv2D(
             embed_dim, 1 + (2 * embed_dim), 1, bias_attr=bias)
         self.attn_dropout = nn.Dropout(p=attn_dropout)
@@ -428,7 +432,7 @@ class LinearSelfAttention(nn.Layer):
 
         # combine context vector with values
         # [B, d, P, N] * [B, d, P, 1] --> [B, d, P, N]
-        out = F.relu(value) * context_vector.expand_as(value)
+        out = F.relu(value) * context_vector
         out = self.out_proj(out)
         return out
 
@@ -552,10 +556,11 @@ class MobileViTv3Block_v2(nn.Layer):
         # [B, C, H, W] --> [B, C, P, N]
         patches = F.unfold(
             feature_map,
-            kernel_sizes=(self.patch_h, self.patch_w),
-            stride=(self.patch_h, self.patch_w))
+            kernel_sizes=[self.patch_h, self.patch_w],
+            strides=[self.patch_h, self.patch_w])
+        n_patches = img_h * img_w // (self.patch_h * self.patch_w)
         patches = patches.reshape(
-            [batch_size, in_channels, self.patch_h * self.patch_w, -1])
+            [batch_size, in_channels, self.patch_h * self.patch_w, n_patches])
 
         return patches, (img_h, img_w)
 
@@ -567,9 +572,9 @@ class MobileViTv3Block_v2(nn.Layer):
 
         feature_map = F.fold(
             patches,
-            output_sizes=output_size,
-            kernel_sizes=(self.patch_h, self.patch_w),
-            stride=(self.patch_h, self.patch_w))
+            output_size,
+            kernel_sizes=[self.patch_h, self.patch_w],
+            strides=[self.patch_h, self.patch_w])
 
         return feature_map
 
@@ -656,16 +661,16 @@ class MobileViTv3(nn.Layer):
             cfg=mobilevit_config["layer5"],
             dilate=dilate_l5)
 
-        in_channels = out_channels
-        exp_channels = min(mobilevit_config["last_layer_exp_factor"] *
-                           in_channels, 960)
         if self.mobilevit_v2_based:
             self.conv_1x1_exp = nn.Identity()
         else:
+            in_channels = out_channels
+            out_channels = min(mobilevit_config["last_layer_exp_factor"] *
+                               in_channels, 960)
             self.conv_1x1_exp = nn.Sequential(
                 ('conv', nn.Conv2D(
-                    in_channels, exp_channels, 1, bias_attr=False)),
-                ('norm', nn.BatchNorm2D(exp_channels)), ('act', nn.Silu()))
+                    in_channels, out_channels, 1, bias_attr=False)),
+                ('norm', nn.BatchNorm2D(out_channels)), ('act', nn.Silu()))
 
         self.classifier = nn.Sequential()
         self.classifier.add_sublayer(
@@ -675,7 +680,7 @@ class MobileViTv3(nn.Layer):
             self.classifier.add_sublayer(
                 name="dropout", sublayer=nn.Dropout(p=classifier_dropout))
         self.classifier.add_sublayer(
-            name="fc", sublayer=nn.Linear(exp_channels, class_num))
+            name="fc", sublayer=nn.Linear(out_channels, class_num))
 
         # weight initialization
         self.apply(self._init_weights)
@@ -1019,6 +1024,216 @@ def MobileViTv3_XXS(pretrained=False, use_ssld=False, **kwargs):
 
     _load_pretrained(
         pretrained, model, MODEL_URLS["MobileViTv3_XXS"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_S_L2(pretrained=False, use_ssld=False, **kwargs):
+    mv2_exp_mult = 4
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 16,
+        },
+        "layer1": {
+            "out_channels": 32,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2"
+        },
+        "layer2": {
+            "out_channels": 64,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 3,
+            "stride": 2,
+            "block_type": "mv2"
+        },
+        "layer3": {  # 28x28
+            "out_channels": 128,
+            "transformer_channels": 144,
+            "ffn_dim": 288,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer4": {  # 14x14
+            "out_channels": 256,
+            "transformer_channels": 192,
+            "ffn_dim": 384,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer5": {  # 7x7
+            "out_channels": 320,
+            "transformer_channels": 240,
+            "ffn_dim": 480,
+            "transformer_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "last_layer_exp_factor": 4
+    }
+
+    model = MobileViTv3(mobilevit_config, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_S_L2"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_XS_L2(pretrained=False, use_ssld=False, **kwargs):
+    mv2_exp_mult = 4
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 16,
+        },
+        "layer1": {
+            "out_channels": 32,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2"
+        },
+        "layer2": {
+            "out_channels": 48,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 3,
+            "stride": 2,
+            "block_type": "mv2"
+        },
+        "layer3": {  # 28x28
+            "out_channels": 96,
+            "transformer_channels": 96,
+            "ffn_dim": 192,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer4": {  # 14x14
+            "out_channels": 160,
+            "transformer_channels": 120,
+            "ffn_dim": 240,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer5": {  # 7x7
+            "out_channels": 160,
+            "transformer_channels": 144,
+            "ffn_dim": 288,
+            "transformer_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "last_layer_exp_factor": 4
+    }
+
+    model = MobileViTv3(mobilevit_config, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_XS_L2"], use_ssld=use_ssld)
+    return model
+
+
+def MobileViTv3_XXS_L2(pretrained=False, use_ssld=False, **kwargs):
+    mv2_exp_mult = 2
+    mobilevit_config = {
+        "layer0": {
+            "img_channels": 3,
+            "out_channels": 16,
+        },
+        "layer1": {
+            "out_channels": 16,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 1,
+            "stride": 1,
+            "block_type": "mv2"
+        },
+        "layer2": {
+            "out_channels": 24,
+            "expand_ratio": mv2_exp_mult,
+            "num_blocks": 3,
+            "stride": 2,
+            "block_type": "mv2"
+        },
+        "layer3": {  # 28x28
+            "out_channels": 64,
+            "transformer_channels": 64,
+            "ffn_dim": 128,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer4": {  # 14x14
+            "out_channels": 80,
+            "transformer_channels": 80,
+            "ffn_dim": 160,
+            "transformer_blocks": 2,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "layer5": {  # 7x7
+            "out_channels": 128,
+            "transformer_channels": 96,
+            "ffn_dim": 192,
+            "transformer_blocks": 3,
+            "patch_h": 2,
+            "patch_w": 2,
+            "stride": 2,
+            "mv_expand_ratio": mv2_exp_mult,
+            "head_dim": None,
+            "num_heads": 4,
+            "block_type": "mobilevit"
+        },
+        "last_layer_exp_factor": 4
+    }
+
+    model = MobileViTv3(mobilevit_config, **kwargs)
+
+    _load_pretrained(
+        pretrained, model, MODEL_URLS["MobileViTv3_XXS_L2"], use_ssld=use_ssld)
     return model
 
 

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -49,9 +50,8 @@ Optimizer:
   epsilon: 1e-8
   weight_decay: 0.01
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 384
     eta_min: 0.0002
     warmup_epoch: 1  # 3000 iterations
     warmup_start_lr: 0.0002
@@ -86,7 +86,7 @@ DataLoader:
       scales: [256, 160, 192, 224, 288, 320]
       # first_bs: batch size for the first image resolution in the scales list
       # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
+      first_bs: 32
       divided_factor: 32
       is_training: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
@@ -55,7 +55,6 @@ Optimizer:
     eta_min: 0.0002
     warmup_epoch: 1  # 3000 iterations
     warmup_start_lr: 0.0002
-    # by_epoch: True
 
 # data loader for train and eval
 DataLoader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
@@ -1,0 +1,152 @@
+# global configs
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: True
+  eval_interval: 1
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: False
+  # used for static mode and model export
+  image_shape: [3, 256, 256]
+  save_inference_dir: ./inference
+  use_dali: False
+
+# mixed precision training
+AMP:
+  scale_loss: 65536
+  use_dynamic_loss_scaling: True
+  # O1: mixed fp16
+  level: O1
+
+# model ema
+EMA:
+  decay: 0.9995
+
+# model architecture
+Arch:
+  name: MobileViTv3_S
+  class_num: 1000
+  dropout: 0.1
+
+# loss function config for traing/eval process
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+        epsilon: 0.1
+  Eval:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  beta1: 0.9
+  beta2: 0.999
+  epsilon: 1e-8
+  weight_decay: 0.01
+  lr:
+    # for 8 cards
+    name: Cosine
+    learning_rate: 0.002
+    eta_min: 0.0002
+    warmup_epoch: 1  # 3000 iterations
+    warmup_start_lr: 0.0002
+    # by_epoch: True
+
+# data loader for train and eval
+DataLoader:
+  Train:
+    dataset:
+      name: MultiScaleDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: True
+            channel_first: False
+        - RandCropImage:
+            size: 256
+            interpolation: bilinear
+            use_log_aspect: True
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    # support to specify width and height respectively:
+    # scales: [(256,256) (160,160), (192,192), (224,224) (288,288) (320,320)]
+    sampler:
+      name: MultiScaleSampler
+      scales: [256, 160, 192, 224, 288, 320]
+      # first_bs: batch size for the first image resolution in the scales list
+      # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
+      first_bs: 48
+      divided_factor: 32
+      is_training: True
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+  Eval:
+    dataset: 
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 288
+            interpolation: bilinear
+        - CropImage:
+            size: 256
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 48
+      drop_last: False
+      shuffle: False
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 10
+  transforms:
+    - DecodeImage:
+        to_rgb: True
+        channel_first: False
+    - ResizeImage:
+        resize_short: 288
+        interpolation: bilinear
+    - CropImage:
+        size: 256
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.0, 0.0, 0.0]
+        std: [1.0, 1.0, 1.0]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Train:
+    - TopkAcc:
+        topk: [1, 5]
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
@@ -99,7 +99,7 @@ DataLoader:
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt
       transform_ops:
         - DecodeImage:
-            to_rgb: False
+            to_rgb: True
             channel_first: False
         - ResizeImage:
             resize_short: 288

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S_L2.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S_L2.yaml
@@ -28,9 +28,9 @@ EMA:
 
 # model architecture
 Arch:
-  name: MobileViTv3_XXS
+  name: MobileViTv3_S_L2
   class_num: 1000
-  dropout: 0.05
+  dropout: 0.1
 
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S_L2.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S_L2.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -49,13 +50,11 @@ Optimizer:
   epsilon: 1e-8
   weight_decay: 0.01
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 384
     eta_min: 0.0002
     warmup_epoch: 1  # 3000 iterations
     warmup_start_lr: 0.0002
-    # by_epoch: True
 
 # data loader for train and eval
 DataLoader:
@@ -86,7 +85,7 @@ DataLoader:
       scales: [256, 160, 192, 224, 288, 320]
       # first_bs: batch size for the first image resolution in the scales list
       # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
+      first_bs: 32
       divided_factor: 32
       is_training: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
@@ -1,0 +1,152 @@
+# global configs
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: True
+  eval_interval: 1
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: False
+  # used for static mode and model export
+  image_shape: [3, 256, 256]
+  save_inference_dir: ./inference
+  use_dali: False
+
+# mixed precision training
+AMP:
+  scale_loss: 65536
+  use_dynamic_loss_scaling: True
+  # O1: mixed fp16
+  level: O1
+
+# model ema
+EMA:
+  decay: 0.9995
+
+# model architecture
+Arch:
+  name: MobileViTv3_XS
+  class_num: 1000
+  dropout: 0.1
+
+# loss function config for traing/eval process
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+        epsilon: 0.1
+  Eval:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  beta1: 0.9
+  beta2: 0.999
+  epsilon: 1e-8
+  weight_decay: 0.01
+  lr:
+    # for 8 cards
+    name: Cosine
+    learning_rate: 0.002
+    eta_min: 0.0002
+    warmup_epoch: 1  # 3000 iterations
+    warmup_start_lr: 0.0002
+    # by_epoch: True
+
+# data loader for train and eval
+DataLoader:
+  Train:
+    dataset:
+      name: MultiScaleDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: True
+            channel_first: False
+        - RandCropImage:
+            size: 256
+            interpolation: bilinear
+            use_log_aspect: True
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    # support to specify width and height respectively:
+    # scales: [(256,256) (160,160), (192,192), (224,224) (288,288) (320,320)]
+    sampler:
+      name: MultiScaleSampler
+      scales: [256, 160, 192, 224, 288, 320]
+      # first_bs: batch size for the first image resolution in the scales list
+      # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
+      first_bs: 48
+      divided_factor: 32
+      is_training: True
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+  Eval:
+    dataset: 
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 288
+            interpolation: bilinear
+        - CropImage:
+            size: 256
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 48
+      drop_last: False
+      shuffle: False
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 10
+  transforms:
+    - DecodeImage:
+        to_rgb: True
+        channel_first: False
+    - ResizeImage:
+        resize_short: 288
+        interpolation: bilinear
+    - CropImage:
+        size: 256
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.0, 0.0, 0.0]
+        std: [1.0, 1.0, 1.0]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Train:
+    - TopkAcc:
+        topk: [1, 5]
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -49,13 +50,11 @@ Optimizer:
   epsilon: 1e-8
   weight_decay: 0.01
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 384
     eta_min: 0.0002
     warmup_epoch: 1  # 3000 iterations
     warmup_start_lr: 0.0002
-    # by_epoch: True
 
 # data loader for train and eval
 DataLoader:
@@ -86,7 +85,7 @@ DataLoader:
       scales: [256, 160, 192, 224, 288, 320]
       # first_bs: batch size for the first image resolution in the scales list
       # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
+      first_bs: 32
       divided_factor: 32
       is_training: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
@@ -99,7 +99,7 @@ DataLoader:
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt
       transform_ops:
         - DecodeImage:
-            to_rgb: False
+            to_rgb: True
             channel_first: False
         - ResizeImage:
             resize_short: 288

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS_L2.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS_L2.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -49,13 +50,11 @@ Optimizer:
   epsilon: 1e-8
   weight_decay: 0.01
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 384
     eta_min: 0.0002
     warmup_epoch: 1  # 3000 iterations
     warmup_start_lr: 0.0002
-    # by_epoch: True
 
 # data loader for train and eval
 DataLoader:
@@ -86,7 +85,7 @@ DataLoader:
       scales: [256, 160, 192, 224, 288, 320]
       # first_bs: batch size for the first image resolution in the scales list
       # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
+      first_bs: 32
       divided_factor: 32
       is_training: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS_L2.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS_L2.yaml
@@ -28,9 +28,9 @@ EMA:
 
 # model architecture
 Arch:
-  name: MobileViTv3_XXS
+  name: MobileViTv3_XS_L2
   class_num: 1000
-  dropout: 0.05
+  dropout: 0.1
 
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -49,13 +50,11 @@ Optimizer:
   epsilon: 1e-8
   weight_decay: 0.01
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 384
     eta_min: 0.0002
     warmup_epoch: 1  # 3000 iterations
     warmup_start_lr: 0.0002
-    # by_epoch: True
 
 # data loader for train and eval
 DataLoader:
@@ -86,7 +85,7 @@ DataLoader:
       scales: [256, 160, 192, 224, 288, 320]
       # first_bs: batch size for the first image resolution in the scales list
       # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
+      first_bs: 32
       divided_factor: 32
       is_training: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS.yaml
@@ -1,0 +1,152 @@
+# global configs
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: True
+  eval_interval: 1
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: False
+  # used for static mode and model export
+  image_shape: [3, 256, 256]
+  save_inference_dir: ./inference
+  use_dali: False
+
+# mixed precision training
+AMP:
+  scale_loss: 65536
+  use_dynamic_loss_scaling: True
+  # O1: mixed fp16
+  level: O1
+
+# model ema
+EMA:
+  decay: 0.9995
+
+# model architecture
+Arch:
+  name: MobileViTv3_XXS
+  class_num: 1000
+  dropout: 0.05
+
+# loss function config for traing/eval process
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+        epsilon: 0.1
+  Eval:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  beta1: 0.9
+  beta2: 0.999
+  epsilon: 1e-8
+  weight_decay: 0.01
+  lr:
+    # for 8 cards
+    name: Cosine
+    learning_rate: 0.002
+    eta_min: 0.0002
+    warmup_epoch: 1  # 3000 iterations
+    warmup_start_lr: 0.0002
+    # by_epoch: True
+
+# data loader for train and eval
+DataLoader:
+  Train:
+    dataset:
+      name: MultiScaleDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: True
+            channel_first: False
+        - RandCropImage:
+            size: 256
+            interpolation: bilinear
+            use_log_aspect: True
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    # support to specify width and height respectively:
+    # scales: [(256,256) (160,160), (192,192), (224,224) (288,288) (320,320)]
+    sampler:
+      name: MultiScaleSampler
+      scales: [256, 160, 192, 224, 288, 320]
+      # first_bs: batch size for the first image resolution in the scales list
+      # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
+      first_bs: 48
+      divided_factor: 32
+      is_training: True
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+  Eval:
+    dataset: 
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 288
+            interpolation: bilinear
+        - CropImage:
+            size: 256
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 48
+      drop_last: False
+      shuffle: False
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 10
+  transforms:
+    - DecodeImage:
+        to_rgb: True
+        channel_first: False
+    - ResizeImage:
+        resize_short: 288
+        interpolation: bilinear
+    - CropImage:
+        size: 256
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.0, 0.0, 0.0]
+        std: [1.0, 1.0, 1.0]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Train:
+    - TopkAcc:
+        topk: [1, 5]
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS_L2.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS_L2.yaml
@@ -28,9 +28,9 @@ EMA:
 
 # model architecture
 Arch:
-  name: MobileViTv3_XXS
+  name: MobileViTv3_XXS_L2
   class_num: 1000
-  dropout: 0.05
+  dropout: 0.1
 
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS_L2.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS_L2.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -49,13 +50,11 @@ Optimizer:
   epsilon: 1e-8
   weight_decay: 0.01
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 384
     eta_min: 0.0002
     warmup_epoch: 1  # 3000 iterations
     warmup_start_lr: 0.0002
-    # by_epoch: True
 
 # data loader for train and eval
 DataLoader:
@@ -86,7 +85,7 @@ DataLoader:
       scales: [256, 160, 192, 224, 288, 320]
       # first_bs: batch size for the first image resolution in the scales list
       # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
+      first_bs: 32
       divided_factor: 32
       is_training: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
@@ -47,48 +47,68 @@ Optimizer:
   beta1: 0.9
   beta2: 0.999
   epsilon: 1e-8
-  weight_decay: 0.01
+  weight_decay: 0.05
+  no_weight_decay_name: .bias norm
+  one_dim_param_no_weight_decay: True
   lr:
     # for 8 cards
     name: Cosine
     learning_rate: 0.002
     eta_min: 0.0002
-    warmup_epoch: 1  # 3000 iterations
-    warmup_start_lr: 0.0002
+    warmup_epoch: 20  # 20000 iterations
+    warmup_start_lr: 1e-6
     # by_epoch: True
+  clip_norm: 10
 
 # data loader for train and eval
 DataLoader:
   Train:
     dataset:
-      name: MultiScaleDataset
+      name: ImageNetDataset
       image_root: ./dataset/ILSVRC2012/
       cls_label_path: ./dataset/ILSVRC2012/train_list.txt
       transform_ops:
         - DecodeImage:
             to_rgb: True
             channel_first: False
+            backend: pil
         - RandCropImage:
             size: 256
-            interpolation: bilinear
+            interpolation: bicubic
+            backend: pil
             use_log_aspect: True
         - RandFlipImage:
             flip_code: 1
+        - TimmAutoAugment:
+            config_str: rand-m9-mstd0.5-inc1
+            interpolation: bicubic
+            img_size: 256
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
             order: ''
-    # support to specify width and height respectively:
-    # scales: [(256,256) (160,160), (192,192), (224,224) (288,288) (320,320)]
+        - RandomErasing:
+            EPSILON: 0.25
+            sl: 0.02
+            sh: 1.0/3.0
+            r1: 0.3
+            attempt: 10
+            use_log_aspect: True
+            mode: pixel
+      batch_transform_ops:
+        - OpSampler:
+            MixupOperator:
+              alpha: 0.2
+              prob: 0.5
+            CutmixOperator:
+              alpha: 1.0
+              prob: 0.5
     sampler:
-      name: MultiScaleSampler
-      scales: [256, 160, 192, 224, 288, 320]
-      # first_bs: batch size for the first image resolution in the scales list
-      # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
-      divided_factor: 32
-      is_training: True
+      name: DistributedBatchSampler
+      batch_size: 128
+      drop_last: False
+      shuffle: False
     loader:
       num_workers: 4
       use_shared_memory: True
@@ -99,11 +119,13 @@ DataLoader:
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt
       transform_ops:
         - DecodeImage:
-            to_rgb: False
+            to_np: False
             channel_first: False
+            backend: pil
         - ResizeImage:
             resize_short: 288
-            interpolation: bilinear
+            interpolation: bicubic
+            backend: pil
         - CropImage:
             size: 256
         - NormalizeImage:
@@ -113,7 +135,7 @@ DataLoader:
             order: ''
     sampler:
       name: DistributedBatchSampler
-      batch_size: 48
+      batch_size: 128
       drop_last: False
       shuffle: False
     loader:
@@ -125,11 +147,13 @@ Infer:
   batch_size: 10
   transforms:
     - DecodeImage:
-        to_rgb: True
+        to_np: False
         channel_first: False
+        backend: pil
     - ResizeImage:
         resize_short: 288
-        interpolation: bilinear
+        interpolation: bicubic
+        backend: pil
     - CropImage:
         size: 256
     - NormalizeImage:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
@@ -79,10 +79,9 @@ DataLoader:
             use_log_aspect: True
         - RandFlipImage:
             flip_code: 1
-        - TimmAutoAugment:
-            config_str: rand-m9-mstd0.5-inc1
+        - RandAugmentV3:
+            num_layers: 2
             interpolation: bicubic
-            img_size: 256
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
@@ -93,15 +93,15 @@ DataLoader:
             r1: 0.3
             attempt: 10
             use_log_aspect: True
-            mode: pixel
+            mode: const
       batch_transform_ops:
         - OpSampler:
             MixupOperator:
               alpha: 0.2
-              prob: 0.5
+              prob: 0.25
             CutmixOperator:
               alpha: 1.0
-              prob: 0.5
+              prob: 0.25
     sampler:
       name: DistributedBatchSampler
       batch_size: 128
@@ -111,7 +111,7 @@ DataLoader:
       num_workers: 4
       use_shared_memory: True
   Eval:
-    dataset: 
+    dataset:
       name: ImageNetDataset
       image_root: ./dataset/ILSVRC2012/
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
@@ -48,14 +48,13 @@ Optimizer:
   beta2: 0.999
   epsilon: 1e-8
   weight_decay: 0.05
-  no_weight_decay_name: .bias norm
   one_dim_param_no_weight_decay: True
   lr:
     # for 8 cards
     name: Cosine
     learning_rate: 0.002
     eta_min: 0.0002
-    warmup_epoch: 20  # 20000 iterations
+    warmup_epoch: 16  # 20000 iterations
     warmup_start_lr: 1e-6
     # by_epoch: True
   clip_norm: 10
@@ -107,7 +106,7 @@ DataLoader:
       name: DistributedBatchSampler
       batch_size: 128
       drop_last: False
-      shuffle: False
+      shuffle: True
     loader:
       num_workers: 4
       use_shared_memory: True

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -50,13 +51,11 @@ Optimizer:
   weight_decay: 0.05
   one_dim_param_no_weight_decay: True
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 1020
     eta_min: 0.0002
     warmup_epoch: 16  # 20000 iterations
     warmup_start_lr: 1e-6
-    # by_epoch: True
   clip_norm: 10
 
 # data loader for train and eval
@@ -104,7 +103,7 @@ DataLoader:
               prob: 0.25
     sampler:
       name: DistributedBatchSampler
-      batch_size: 128
+      batch_size: 85
       drop_last: False
       shuffle: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
@@ -1,0 +1,152 @@
+# global configs
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: True
+  eval_interval: 1
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: False
+  # used for static mode and model export
+  image_shape: [3, 256, 256]
+  save_inference_dir: ./inference
+  use_dali: False
+
+# mixed precision training
+AMP:
+  scale_loss: 65536
+  use_dynamic_loss_scaling: True
+  # O1: mixed fp16
+  level: O1
+
+# model ema
+EMA:
+  decay: 0.9995
+
+# model architecture
+Arch:
+  name: MobileViTv3_x0_5
+  class_num: 1000
+  classifier_dropout: 0.
+
+# loss function config for traing/eval process
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+        epsilon: 0.1
+  Eval:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  beta1: 0.9
+  beta2: 0.999
+  epsilon: 1e-8
+  weight_decay: 0.01
+  lr:
+    # for 8 cards
+    name: Cosine
+    learning_rate: 0.002
+    eta_min: 0.0002
+    warmup_epoch: 1  # 3000 iterations
+    warmup_start_lr: 0.0002
+    # by_epoch: True
+
+# data loader for train and eval
+DataLoader:
+  Train:
+    dataset:
+      name: MultiScaleDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: True
+            channel_first: False
+        - RandCropImage:
+            size: 256
+            interpolation: bilinear
+            use_log_aspect: True
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    # support to specify width and height respectively:
+    # scales: [(256,256) (160,160), (192,192), (224,224) (288,288) (320,320)]
+    sampler:
+      name: MultiScaleSampler
+      scales: [256, 160, 192, 224, 288, 320]
+      # first_bs: batch size for the first image resolution in the scales list
+      # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
+      first_bs: 48
+      divided_factor: 32
+      is_training: True
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+  Eval:
+    dataset: 
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: False
+            channel_first: False
+        - ResizeImage:
+            resize_short: 288
+            interpolation: bilinear
+        - CropImage:
+            size: 256
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.0, 0.0, 0.0]
+            std: [1.0, 1.0, 1.0]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 48
+      drop_last: False
+      shuffle: False
+    loader:
+      num_workers: 4
+      use_shared_memory: True
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 10
+  transforms:
+    - DecodeImage:
+        to_rgb: True
+        channel_first: False
+    - ResizeImage:
+        resize_short: 288
+        interpolation: bilinear
+    - CropImage:
+        size: 256
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.0, 0.0, 0.0]
+        std: [1.0, 1.0, 1.0]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Train:
+    - TopkAcc:
+        topk: [1, 5]
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
@@ -28,9 +28,9 @@ EMA:
 
 # model architecture
 Arch:
-  name: MobileViTv3_XXS
+  name: MobileViTv3_x0_75
   class_num: 1000
-  dropout: 0.05
+  classifier_dropout: 0.
 
 # loss function config for traing/eval process
 Loss:
@@ -47,48 +47,68 @@ Optimizer:
   beta1: 0.9
   beta2: 0.999
   epsilon: 1e-8
-  weight_decay: 0.01
+  weight_decay: 0.05
+  no_weight_decay_name: .bias norm
+  one_dim_param_no_weight_decay: True
   lr:
     # for 8 cards
     name: Cosine
     learning_rate: 0.002
     eta_min: 0.0002
-    warmup_epoch: 1  # 3000 iterations
-    warmup_start_lr: 0.0002
+    warmup_epoch: 20  # 20000 iterations
+    warmup_start_lr: 1e-6
     # by_epoch: True
+  clip_norm: 10
 
 # data loader for train and eval
 DataLoader:
   Train:
     dataset:
-      name: MultiScaleDataset
+      name: ImageNetDataset
       image_root: ./dataset/ILSVRC2012/
       cls_label_path: ./dataset/ILSVRC2012/train_list.txt
       transform_ops:
         - DecodeImage:
             to_rgb: True
             channel_first: False
+            backend: pil
         - RandCropImage:
             size: 256
-            interpolation: bilinear
+            interpolation: bicubic
+            backend: pil
             use_log_aspect: True
         - RandFlipImage:
             flip_code: 1
+        - TimmAutoAugment:
+            config_str: rand-m9-mstd0.5-inc1
+            interpolation: bicubic
+            img_size: 256
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
             order: ''
-    # support to specify width and height respectively:
-    # scales: [(256,256) (160,160), (192,192), (224,224) (288,288) (320,320)]
+        - RandomErasing:
+            EPSILON: 0.25
+            sl: 0.02
+            sh: 1.0/3.0
+            r1: 0.3
+            attempt: 10
+            use_log_aspect: True
+            mode: pixel
+      batch_transform_ops:
+        - OpSampler:
+            MixupOperator:
+              alpha: 0.2
+              prob: 0.5
+            CutmixOperator:
+              alpha: 1.0
+              prob: 0.5
     sampler:
-      name: MultiScaleSampler
-      scales: [256, 160, 192, 224, 288, 320]
-      # first_bs: batch size for the first image resolution in the scales list
-      # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
-      divided_factor: 32
-      is_training: True
+      name: DistributedBatchSampler
+      batch_size: 128
+      drop_last: False
+      shuffle: False
     loader:
       num_workers: 4
       use_shared_memory: True
@@ -99,11 +119,13 @@ DataLoader:
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt
       transform_ops:
         - DecodeImage:
-            to_rgb: True
+            to_np: False
             channel_first: False
+            backend: pil
         - ResizeImage:
             resize_short: 288
-            interpolation: bilinear
+            interpolation: bicubic
+            backend: pil
         - CropImage:
             size: 256
         - NormalizeImage:
@@ -113,7 +135,7 @@ DataLoader:
             order: ''
     sampler:
       name: DistributedBatchSampler
-      batch_size: 48
+      batch_size: 128
       drop_last: False
       shuffle: False
     loader:
@@ -125,11 +147,13 @@ Infer:
   batch_size: 10
   transforms:
     - DecodeImage:
-        to_rgb: True
+        to_np: False
         channel_first: False
+        backend: pil
     - ResizeImage:
         resize_short: 288
-        interpolation: bilinear
+        interpolation: bicubic
+        backend: pil
     - CropImage:
         size: 256
     - NormalizeImage:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
@@ -79,10 +79,9 @@ DataLoader:
             use_log_aspect: True
         - RandFlipImage:
             flip_code: 1
-        - TimmAutoAugment:
-            config_str: rand-m9-mstd0.5-inc1
+        - RandAugmentV3:
+            num_layers: 2
             interpolation: bicubic
-            img_size: 256
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
@@ -93,15 +93,15 @@ DataLoader:
             r1: 0.3
             attempt: 10
             use_log_aspect: True
-            mode: pixel
+            mode: const
       batch_transform_ops:
         - OpSampler:
             MixupOperator:
               alpha: 0.2
-              prob: 0.5
+              prob: 0.25
             CutmixOperator:
               alpha: 1.0
-              prob: 0.5
+              prob: 0.25
     sampler:
       name: DistributedBatchSampler
       batch_size: 128
@@ -111,7 +111,7 @@ DataLoader:
       num_workers: 4
       use_shared_memory: True
   Eval:
-    dataset: 
+    dataset:
       name: ImageNetDataset
       image_root: ./dataset/ILSVRC2012/
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
@@ -48,14 +48,13 @@ Optimizer:
   beta2: 0.999
   epsilon: 1e-8
   weight_decay: 0.05
-  no_weight_decay_name: .bias norm
   one_dim_param_no_weight_decay: True
   lr:
     # for 8 cards
     name: Cosine
     learning_rate: 0.002
     eta_min: 0.0002
-    warmup_epoch: 20  # 20000 iterations
+    warmup_epoch: 16  # 20000 iterations
     warmup_start_lr: 1e-6
     # by_epoch: True
   clip_norm: 10
@@ -107,7 +106,7 @@ DataLoader:
       name: DistributedBatchSampler
       batch_size: 128
       drop_last: False
-      shuffle: False
+      shuffle: True
     loader:
       num_workers: 4
       use_shared_memory: True

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -50,13 +51,11 @@ Optimizer:
   weight_decay: 0.05
   one_dim_param_no_weight_decay: True
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 1020
     eta_min: 0.0002
     warmup_epoch: 16  # 20000 iterations
     warmup_start_lr: 1e-6
-    # by_epoch: True
   clip_norm: 10
 
 # data loader for train and eval
@@ -104,7 +103,7 @@ DataLoader:
               prob: 0.25
     sampler:
       name: DistributedBatchSampler
-      batch_size: 128
+      batch_size: 85
       drop_last: False
       shuffle: True
     loader:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
@@ -28,9 +28,9 @@ EMA:
 
 # model architecture
 Arch:
-  name: MobileViTv3_XXS
+  name: MobileViTv3_x1_0
   class_num: 1000
-  dropout: 0.05
+  classifier_dropout: 0.
 
 # loss function config for traing/eval process
 Loss:
@@ -47,48 +47,68 @@ Optimizer:
   beta1: 0.9
   beta2: 0.999
   epsilon: 1e-8
-  weight_decay: 0.01
+  weight_decay: 0.05
+  no_weight_decay_name: .bias norm
+  one_dim_param_no_weight_decay: True
   lr:
     # for 8 cards
     name: Cosine
     learning_rate: 0.002
     eta_min: 0.0002
-    warmup_epoch: 1  # 3000 iterations
-    warmup_start_lr: 0.0002
+    warmup_epoch: 20  # 20000 iterations
+    warmup_start_lr: 1e-6
     # by_epoch: True
+  clip_norm: 10
 
 # data loader for train and eval
 DataLoader:
   Train:
     dataset:
-      name: MultiScaleDataset
+      name: ImageNetDataset
       image_root: ./dataset/ILSVRC2012/
       cls_label_path: ./dataset/ILSVRC2012/train_list.txt
       transform_ops:
         - DecodeImage:
             to_rgb: True
             channel_first: False
+            backend: pil
         - RandCropImage:
             size: 256
-            interpolation: bilinear
+            interpolation: bicubic
+            backend: pil
             use_log_aspect: True
         - RandFlipImage:
             flip_code: 1
+        - TimmAutoAugment:
+            config_str: rand-m9-mstd0.5-inc1
+            interpolation: bicubic
+            img_size: 256
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
             order: ''
-    # support to specify width and height respectively:
-    # scales: [(256,256) (160,160), (192,192), (224,224) (288,288) (320,320)]
+        - RandomErasing:
+            EPSILON: 0.25
+            sl: 0.02
+            sh: 1.0/3.0
+            r1: 0.3
+            attempt: 10
+            use_log_aspect: True
+            mode: pixel
+      batch_transform_ops:
+        - OpSampler:
+            MixupOperator:
+              alpha: 0.2
+              prob: 0.5
+            CutmixOperator:
+              alpha: 1.0
+              prob: 0.5
     sampler:
-      name: MultiScaleSampler
-      scales: [256, 160, 192, 224, 288, 320]
-      # first_bs: batch size for the first image resolution in the scales list
-      # divide_factor: to ensure the width and height dimensions can be devided by downsampling multiple
-      first_bs: 48
-      divided_factor: 32
-      is_training: True
+      name: DistributedBatchSampler
+      batch_size: 128
+      drop_last: False
+      shuffle: False
     loader:
       num_workers: 4
       use_shared_memory: True
@@ -99,11 +119,13 @@ DataLoader:
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt
       transform_ops:
         - DecodeImage:
-            to_rgb: True
+            to_np: False
             channel_first: False
+            backend: pil
         - ResizeImage:
             resize_short: 288
-            interpolation: bilinear
+            interpolation: bicubic
+            backend: pil
         - CropImage:
             size: 256
         - NormalizeImage:
@@ -113,7 +135,7 @@ DataLoader:
             order: ''
     sampler:
       name: DistributedBatchSampler
-      batch_size: 48
+      batch_size: 128
       drop_last: False
       shuffle: False
     loader:
@@ -125,11 +147,13 @@ Infer:
   batch_size: 10
   transforms:
     - DecodeImage:
-        to_rgb: True
+        to_np: False
         channel_first: False
+        backend: pil
     - ResizeImage:
         resize_short: 288
-        interpolation: bilinear
+        interpolation: bicubic
+        backend: pil
     - CropImage:
         size: 256
     - NormalizeImage:

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
@@ -79,10 +79,9 @@ DataLoader:
             use_log_aspect: True
         - RandFlipImage:
             flip_code: 1
-        - TimmAutoAugment:
-            config_str: rand-m9-mstd0.5-inc1
+        - RandAugmentV3:
+            num_layers: 2
             interpolation: bicubic
-            img_size: 256
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
@@ -93,15 +93,15 @@ DataLoader:
             r1: 0.3
             attempt: 10
             use_log_aspect: True
-            mode: pixel
+            mode: const
       batch_transform_ops:
         - OpSampler:
             MixupOperator:
               alpha: 0.2
-              prob: 0.5
+              prob: 0.25
             CutmixOperator:
               alpha: 1.0
-              prob: 0.5
+              prob: 0.25
     sampler:
       name: DistributedBatchSampler
       batch_size: 128
@@ -111,7 +111,7 @@ DataLoader:
       num_workers: 4
       use_shared_memory: True
   Eval:
-    dataset: 
+    dataset:
       name: ImageNetDataset
       image_root: ./dataset/ILSVRC2012/
       cls_label_path: ./dataset/ILSVRC2012/val_list.txt

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
@@ -48,14 +48,13 @@ Optimizer:
   beta2: 0.999
   epsilon: 1e-8
   weight_decay: 0.05
-  no_weight_decay_name: .bias norm
   one_dim_param_no_weight_decay: True
   lr:
     # for 8 cards
     name: Cosine
     learning_rate: 0.002
     eta_min: 0.0002
-    warmup_epoch: 20  # 20000 iterations
+    warmup_epoch: 16  # 20000 iterations
     warmup_start_lr: 1e-6
     # by_epoch: True
   clip_norm: 10
@@ -107,7 +106,7 @@ DataLoader:
       name: DistributedBatchSampler
       batch_size: 128
       drop_last: False
-      shuffle: False
+      shuffle: True
     loader:
       num_workers: 4
       use_shared_memory: True

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
@@ -14,6 +14,7 @@ Global:
   image_shape: [3, 256, 256]
   save_inference_dir: ./inference
   use_dali: False
+  update_freq: 3  # for 4 gpus
 
 # mixed precision training
 AMP:
@@ -50,13 +51,11 @@ Optimizer:
   weight_decay: 0.05
   one_dim_param_no_weight_decay: True
   lr:
-    # for 8 cards
     name: Cosine
-    learning_rate: 0.002
+    learning_rate: 0.002  # for total batch size 1020
     eta_min: 0.0002
     warmup_epoch: 16  # 20000 iterations
     warmup_start_lr: 1e-6
-    # by_epoch: True
   clip_norm: 10
 
 # data loader for train and eval
@@ -104,7 +103,7 @@ DataLoader:
               prob: 0.25
     sampler:
       name: DistributedBatchSampler
-      batch_size: 128
+      batch_size: 85
       drop_last: False
       shuffle: True
     loader:

--- a/ppcls/data/dataloader/multi_scale_sampler.py
+++ b/ppcls/data/dataloader/multi_scale_sampler.py
@@ -103,6 +103,7 @@ class MultiScaleSampler(Sampler):
                 random.seed(self.seed)
             else:
                 random.seed(self.epoch)
+            self.epoch += 1
             random.shuffle(self.img_indices)
             random.shuffle(self.img_batch_pairs)
             indices_rank_i = self.img_indices[self.rank:len(self.img_indices):

--- a/ppcls/data/preprocess/batch_ops/batch_operators.py
+++ b/ppcls/data/preprocess/batch_ops/batch_operators.py
@@ -88,7 +88,7 @@ class MixupOperator(BatchOperator):
 
     def __call__(self, batch):
         imgs, labels, bs = self._unpack(batch)
-        idx = np.random.permutation(bs)
+        idx = np.arange(bs)[::-1]
         lam = np.random.beta(self._alpha, self._alpha)
         imgs = lam * imgs + (1 - lam) * imgs[idx]
         targets = self._mix_target(labels, labels[idx], lam)
@@ -143,7 +143,7 @@ class CutmixOperator(BatchOperator):
 
     def __call__(self, batch):
         imgs, labels, bs = self._unpack(batch)
-        idx = np.random.permutation(bs)
+        idx = np.arange(bs)[::-1]
         lam = np.random.beta(self._alpha, self._alpha)
 
         bbx1, bby1, bbx2, bby2 = self._rand_bbox(imgs.shape, lam)
@@ -179,7 +179,7 @@ class FmixOperator(BatchOperator):
 
     def __call__(self, batch):
         imgs, labels, bs = self._unpack(batch)
-        idx = np.random.permutation(bs)
+        idx = np.arange(bs)[::-1]
         size = (imgs.shape[2], imgs.shape[3])
         lam, mask = sample_mask(self._alpha, self._decay_power, \
                 size, self._max_soft, self._reformulate)

--- a/ppcls/data/preprocess/ops/operators.py
+++ b/ppcls/data/preprocess/ops/operators.py
@@ -746,8 +746,8 @@ class Pad(object):
         # Process fill color for affine transforms
         major_found, minor_found = (int(v)
                                     for v in PILLOW_VERSION.split('.')[:2])
-        major_required, minor_required = (int(v) for v in
-                                          min_pil_version.split('.')[:2])
+        major_required, minor_required = (
+            int(v) for v in min_pil_version.split('.')[:2])
         if major_found < major_required or (major_found == major_required and
                                             minor_found < minor_required):
             if fill is None:

--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -369,6 +369,9 @@ class Engine(object):
                                      ema_module)
             if metric_info is not None:
                 best_metric.update(metric_info)
+            if hasattr(self.train_dataloader.batch_sampler, "set_epoch"):
+                self.train_dataloader.batch_sampler.set_epoch(best_metric[
+                    "epoch"])
 
         for epoch_id in range(best_metric["epoch"] + 1,
                               self.config["Global"]["epochs"] + 1):

--- a/ppcls/utils/ema.py
+++ b/ppcls/utils/ema.py
@@ -32,11 +32,14 @@ class ExponentialMovingAverage():
 
     @paddle.no_grad()
     def _update(self, model, update_fn):
-        for ema_v, model_v in zip(self.module.state_dict().values(), model.state_dict().values()):
-            ema_v.set_value(update_fn(ema_v, model_v))
+        for ema_v, model_v in zip(self.module.state_dict().values(),
+                                  model.state_dict().values()):
+            ema_v.set_value(update_fn(ema_v.numpy(), model_v.numpy()))
 
     def update(self, model):
-        self._update(model, update_fn=lambda e, m: self.decay * e + (1. - self.decay) * m)
+        self._update(
+            model,
+            update_fn=lambda e, m: self.decay * e + (1. - self.decay) * m)
 
     def set(self, model):
         self._update(model, update_fn=lambda e, m: m)

--- a/ppcls/utils/ema.py
+++ b/ppcls/utils/ema.py
@@ -32,14 +32,11 @@ class ExponentialMovingAverage():
 
     @paddle.no_grad()
     def _update(self, model, update_fn):
-        for ema_v, model_v in zip(self.module.state_dict().values(),
-                                  model.state_dict().values()):
-            ema_v.set_value(update_fn(ema_v.numpy(), model_v.numpy()))
+        for ema_v, model_v in zip(self.module.state_dict().values(), model.state_dict().values()):
+            ema_v.set_value(update_fn(ema_v, model_v))
 
     def update(self, model):
-        self._update(
-            model,
-            update_fn=lambda e, m: self.decay * e + (1. - self.decay) * m)
+        self._update(model, update_fn=lambda e, m: self.decay * e + (1. - self.decay) * m)
 
     def set(self, model):
         self._update(model, update_fn=lambda e, m: m)

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_S_L2_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_S_L2_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_S_L2
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.first_bs:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S_L2.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S_L2.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S_L2.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_S_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_S_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_S
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.first_bs:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_S.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_XS_L2_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_XS_L2_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_XS_L2
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.first_bs:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS_L2.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS_L2.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS_L2.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_XS_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_XS_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_XS
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.first_bs:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XS.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_XXS_L2_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_XXS_L2_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_XXS_L2
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.first_bs:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS_L2.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS_L2.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS_L2.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_XXS_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_XXS_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_XXS
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.first_bs:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_XXS.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_x0_5_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_x0_5_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_x0_5
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.batch_size:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_x0_75_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_x0_75_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_x0_75
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.batch_size:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]

--- a/test_tipc/configs/MobileViTv3/MobileViTv3_x1_0_train_infer_python.txt
+++ b/test_tipc/configs/MobileViTv3/MobileViTv3_x1_0_train_infer_python.txt
@@ -1,0 +1,61 @@
+===========================train_params===========================
+model_name:MobileViTv3_x1_0
+python:python3.7
+gpu_list:0|0,1
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=2|whole_train_whole_infer=120
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.batch_size:8
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+null:null
+##
+trainer:norm_train
+norm_train:tools/train.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml -o Global.seed=1234 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.print_batch_step=1 -o Global.eval_during_train=False -o Global.save_interval=2
+pact_train:null
+fpgm_train:null
+distill_train:null
+null:null
+null:null
+##
+===========================eval_params===========================
+eval:tools/eval.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+inference_dir:null
+infer_model:../inference/
+infer_export:True
+infer_quant:Fasle
+inference:python/predict_cls.py -c configs/inference_cls.yaml -o PreProcess.transform_ops.0.ResizeImage.resize_short=288 -o PreProcess.transform_ops.1.CropImage.size=256 -o PreProcess.transform_ops.2.NormalizeImage.mean=[0.,0.,0.] -o PreProcess.transform_ops.2.NormalizeImage.std=[1.,1.,1.]
+-o Global.use_gpu:True|False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/ILSVRC2012_val_00000001.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+null:null
+null:null
+===========================train_benchmark_params==========================
+batch_size:128
+fp_items:fp32
+epoch:1
+model_type:norm_train
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,256,256]}]


### PR DESCRIPTION
任务详情： [[飞桨黑客松第四期任务总览] Paddle#51281](https://github.com/PaddlePaddle/Paddle/issues/51281#clas)

# 修改内容
1. ~[bugfix]当`DecodeImage`使用`pil` backend时，image类型应转为RGB~
2. ~[[update]](https://github.com/PaddlePaddle/PaddleClas/pull/2691/commits/9312df585319b6714b4e8eb730bfdfed20672109) 在`ExponentialMovingAverage`中使用numpy来完成ema weight的更新，可以一定程度上提速(大概快一倍)~
3. [[bugfix]](https://github.com/PaddlePaddle/PaddleClas/pull/2691/commits/4b315aeb1cc0b3e01c9b1e5bd787ea60cd6c920e) 在`MixupOperator`、`CutmixOperator`和`FmixOperator`中，索引打乱的方法存在一定缺陷，`np.random.permutation`可能造成部分索引在打乱前后顺序不变。改为逆序打乱索引。
4. ~[update] 为`RandCropImage`添加`use_log_aspect`的支持~
5. [[bugfix]](https://github.com/PaddlePaddle/PaddleClas/pull/2691/commits/d1e2a3f87ff621ad9e4b171d61f8e75dbfc51f94) 修复`MultiScaleSampler`中`epoch`不自增的bug
6. [[bugfix]](https://github.com/PaddlePaddle/PaddleClas/pull/2691/commits/f62533b87bd6514c26b9c363aa1ec3e9b07ce832) 当使用checkpoint恢复训练时，更新sampler中的`epoch`为当前的epoch
7. [[add]](https://github.com/PaddlePaddle/PaddleClas/pull/2691/commits/9ed3a8413ba0b3dcb21b0d675ee3c35c78780cf2) 增加`RandAugmentV3`，用于MobileViTv3-v2模型的训练
8. [[add]](https://github.com/PaddlePaddle/PaddleClas/pull/2691/commits/9ed3a8413ba0b3dcb21b0d675ee3c35c78780cf2) 增加MobileViTv3算法，包括model、config、test_tipc、doc

# 复现精度
## 测试
| Models           | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | FLOPs<br>(G) | Params<br>(M) |
|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
| MobileViTv3_XXS    | 0.7087 | 0.8976 | 0.7098 | - |  289.02 | 1.25 |
| MobileViTv3_XS     | 0.7663 | 0.9332 | 0.7671 | - |  926.98 | 2.49 |
| MobileViTv3_S      | 0.7928 | 0.9454 | 0.7930 | - | 1841.39 | 5.76 |
| MobileViTv3_XXS_L2 | 0.7028 | 0.8942 | 0.7023 | - |  256.97 | 1.15 |
| MobileViTv3_XS_L2  | 0.7607 | 0.9300 | 0.7610 | - |  852.82 | 2.26 |
| MobileViTv3_S_L2   | 0.7907 | 0.9440 | 0.7906 | - | 1651.96 | 5.17 |
| MobileViTv3_x0_5   | 0.7200 | 0.9083 | 0.7233 | - |  481.33 | 1.43 |
| MobileViTv3_x0_75  | 0.7626 | 0.9308 | 0.7655 | - | 1064.48 | 3.00 |
| MobileViTv3_x1_0   | 0.7838 | 0.9421 | 0.7864 | - | 1875.96 | 5.14 |

## 训练
训练平台AIStudio：python3.7 + paddle2.4.0 + cuda11.2 + 4 * V100 32GB
| Models | Top1 | Top5 | Reference<br>top1 | Reference<br>top5 | weight & log |
|:--:|:--:|:--:|:--:|:--:|:--:|
| MobileViTv3_S | 0.7915 | 0.9452 | 0.7928 | - | best_model_ema.ema.paparams & train.log |

权重及训练日志下载地址：[百度网盘](https://pan.baidu.com/s/14-QYPbHO6sjnfIe_qEtqcg?pwd=embk)