### PR TITLE
refactor RandAugment, RandAugmentV2 and RandAugmentV3

### DIFF
--- a/ppcls/configs/ImageNet/EfficientNetV2/EfficientNetV2_S.yaml
+++ b/ppcls/configs/ImageNet/EfficientNetV2/EfficientNetV2_S.yaml
@@ -70,8 +70,9 @@ DataLoader:
             flip_code: 1
         - RandAugmentV2:
             num_layers: 2
-            magnitude: 5.0
-            progress_magnitude: [5.0, 8.3333333333, 11.66666666667, 15.0]
+            magnitude: 5
+            interpolation: nearest
+            # progress_magnitude: [5.0, 8.3333333333, 11.66666666667, 15.0]
         - NormalizeImage:
             scale: 1.0
             mean: [128.0, 128.0, 128.0]

--- a/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x0_5.yaml
@@ -77,7 +77,8 @@ DataLoader:
             flip_code: 1
         - RandAugmentV3:
             num_layers: 2
-            interpolation: bicubic
+            magnitude: 3
+            fillcolor: [0, 0, 0]
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x1_0.yaml
@@ -77,7 +77,8 @@ DataLoader:
             flip_code: 1
         - RandAugmentV3:
             num_layers: 2
-            interpolation: bicubic
+            magnitude: 3
+            fillcolor: [0, 0, 0]
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x1_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x1_5.yaml
@@ -77,7 +77,8 @@ DataLoader:
             flip_code: 1
         - RandAugmentV3:
             num_layers: 2
-            interpolation: bicubic
+            magnitude: 3
+            fillcolor: [0, 0, 0]
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x2_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTV2/MobileViTV2_x2_0.yaml
@@ -77,7 +77,8 @@ DataLoader:
             flip_code: 1
         - RandAugmentV3:
             num_layers: 2
-            interpolation: bicubic
+            magnitude: 3
+            fillcolor: [0, 0, 0]
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_5.yaml
@@ -79,7 +79,8 @@ DataLoader:
             flip_code: 1
         - RandAugmentV3:
             num_layers: 2
-            interpolation: bicubic
+            magnitude: 3
+            fillcolor: [0, 0, 0]
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x0_75.yaml
@@ -79,7 +79,8 @@ DataLoader:
             flip_code: 1
         - RandAugmentV3:
             num_layers: 2
-            interpolation: bicubic
+            magnitude: 3
+            fillcolor: [0, 0, 0]
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]

--- a/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileViTv3/MobileViTv3_x1_0.yaml
@@ -79,7 +79,8 @@ DataLoader:
             flip_code: 1
         - RandAugmentV3:
             num_layers: 2
-            interpolation: bicubic
+            magnitude: 3
+            fillcolor: [0, 0, 0]
         - NormalizeImage:
             scale: 1.0/255.0
             mean: [0.0, 0.0, 0.0]


### PR DESCRIPTION
1. 重构前后`RandAugment`的行为有一些不同：重构前`translateX`,`translateY`和`rotate`未指定`resample`方式（默认为`NEAREST`），重构后指定`resample`为`BICUBIC`。
2. 原先的`RandAugmentV2`中，`progress_magnitude`参数未起作用，这次重构暂时注释掉了。