### PR TITLE
fix data dtype for amp training

### DIFF
--- a/ppcls/static/program.py
+++ b/ppcls/static/program.py
@@ -242,11 +242,14 @@ def build(config,
             mode = "Train" if is_train else "Eval"
             use_mix = "batch_transform_ops" in config["DataLoader"][mode][
                 "dataset"]
+            data_dtype = "float32"
+            if 'AMP' in config and config["AMP"]["level"] == 'O2':
+                data_dtype = "float16"
             feeds = create_feeds(
                 config["Global"]["image_shape"],
                 use_mix,
                 class_num=class_num,
-                dtype="float32")
+                dtype=data_dtype)
 
             # build model
             # data_format should be assigned in arch-dict


### PR DESCRIPTION
静态图AMP升级后，修复了原始的AMP bug，导致运行报错。原因：
框架旧版本静态图的AMP-O2，直接将program的 fp32 data修改为fp16类型，feed fp16类型，这样运行是通过的，但是实际program的data 类型，应该与feed的数据一致。由于这个bug的存在，模型写法虽然存在问题，但是运行并不会报错。