### PR TITLE
specify pillow version >= 9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 prettytable
 ujson
 opencv-python<=4.6.0.66
-pillow
+pillow>=9.0.0
 tqdm
 PyYAML>=5.1
 visualdl>=2.2.0


### PR DESCRIPTION
the different version(such as 8.3.2 and 9.x) result in diff in eval top1 acc