### PR TITLE
disable promote kernel for amp training

### DIFF
--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -258,6 +258,7 @@ class Engine(object):
                 use_dynamic_loss_scaling=self.use_dynamic_loss_scaling)
 
             self.amp_level = self.config['AMP'].get("level", "O1")
+            self.use_promote = self.config['AMP'].get("use_promote", False)
             if self.amp_level not in ["O1", "O2"]:
                 msg = "[Parameter Error]: The optimize level of AMP only support 'O1' and 'O2'. The level has been set 'O1'."
                 logger.warning(msg)
@@ -508,7 +509,9 @@ class Engine(object):
                 batch_tensor = paddle.to_tensor(batch_data)
 
                 if self.amp and self.amp_eval:
-                    with paddle.amp.auto_cast(level=self.amp_level):
+                    with paddle.amp.auto_cast(
+                            level=self.amp_level,
+                            use_promote=self.use_promote):
                         out = self.model(batch_tensor)
                 else:
                     out = self.model(batch_tensor)

--- a/ppcls/engine/evaluation/classification.py
+++ b/ppcls/engine/evaluation/classification.py
@@ -56,7 +56,8 @@ def classification_eval(engine, epoch_id=0):
 
         # image input
         if engine.amp and engine.amp_eval:
-            with paddle.amp.auto_cast(level=engine.amp_level):
+            with paddle.amp.auto_cast(
+                    level=engine.amp_level, use_promote=engine.use_promote):
                 out = engine.model(batch[0])
         else:
             out = engine.model(batch[0])
@@ -110,7 +111,9 @@ def classification_eval(engine, epoch_id=0):
         # calc loss
         if engine.eval_loss_func is not None:
             if engine.amp and engine.amp_eval:
-                with paddle.amp.auto_cast(level=engine.amp_level):
+                with paddle.amp.auto_cast(
+                        level=engine.amp_level,
+                        use_promote=engine.use_promote):
                     loss_dict = engine.eval_loss_func(preds, labels)
             else:
                 loss_dict = engine.eval_loss_func(preds, labels)

--- a/ppcls/engine/evaluation/retrieval.py
+++ b/ppcls/engine/evaluation/retrieval.py
@@ -137,7 +137,8 @@ def compute_feature(engine, name="gallery"):
             has_camera = True
             batch[2] = batch[2].reshape([-1, 1]).astype("int64")
         if engine.amp and engine.amp_eval:
-            with paddle.amp.auto_cast(level=engine.amp_level):
+            with paddle.amp.auto_cast(
+                    level=engine.amp_level, use_promote=engine.use_promote):
                 out = engine.model(batch[0])
         else:
             out = engine.model(batch[0])

--- a/ppcls/engine/train/train.py
+++ b/ppcls/engine/train/train.py
@@ -50,7 +50,9 @@ def train_epoch(engine, epoch_id, print_batch_step):
         # image input
         if engine.amp:
             amp_level = engine.config["AMP"].get("level", "O1").upper()
-            with paddle.amp.auto_cast(level=amp_level):
+            use_promote = engine.config["AMP"].get("use_promote", False)
+            with paddle.amp.auto_cast(
+                    level=amp_level, use_promote=use_promote):
                 out = forward(engine, batch)
                 loss_dict = engine.train_loss_func(out, batch[1])
         else:

--- a/ppcls/engine/train/train_fixmatch.py
+++ b/ppcls/engine/train/train_fixmatch.py
@@ -64,7 +64,9 @@ def train_epoch_fixmatch(engine, epoch_id, print_batch_step):
         # image input
         if engine.amp:
             amp_level = engine.config['AMP'].get("level", "O1").upper()
-            with paddle.amp.auto_cast(level=amp_level):
+            use_promote = engine.config["AMP"].get("use_promote", False)
+            with paddle.amp.auto_cast(
+                    level=amp_level, use_promote=use_promote):
                 loss_dict, logits_label = get_loss(
                     engine, inputs, batch_size_label, temperture, threshold,
                     targets_x)

--- a/ppcls/engine/train/train_metabin.py
+++ b/ppcls/engine/train/train_metabin.py
@@ -191,7 +191,8 @@ def forward(engine, batch, loss_func):
     batch_info = {"label": batch[1], "domain": batch[2]}
     if engine.amp:
         amp_level = engine.config["AMP"].get("level", "O1").upper()
-        with paddle.amp.auto_cast(level=amp_level):
+        use_promote = engine.config["AMP"].get("use_promote", False)
+        with paddle.amp.auto_cast(level=amp_level, use_promote=use_promote):
             out = engine.model(batch[0], batch[1])
             loss_dict = loss_func(out, batch_info)
     else:

--- a/ppcls/static/program.py
+++ b/ppcls/static/program.py
@@ -242,11 +242,14 @@ def build(config,
             mode = "Train" if is_train else "Eval"
             use_mix = "batch_transform_ops" in config["DataLoader"][mode][
                 "dataset"]
+            data_dtype = "float32"
+            if 'AMP' in config and config["AMP"]["level"] == 'O2':
+                data_dtype = "float16"
             feeds = create_feeds(
                 config["Global"]["image_shape"],
                 use_mix,
                 class_num=class_num,
-                dtype="float32")
+                dtype=data_dtype)
 
             # build model
             # data_format should be assigned in arch-dict

--- a/ppcls/static/program.py
+++ b/ppcls/static/program.py
@@ -242,14 +242,11 @@ def build(config,
             mode = "Train" if is_train else "Eval"
             use_mix = "batch_transform_ops" in config["DataLoader"][mode][
                 "dataset"]
-            data_dtype = "float32"
-            if 'AMP' in config and config["AMP"]["level"] == 'O2':
-                data_dtype = "float16"
             feeds = create_feeds(
                 config["Global"]["image_shape"],
                 use_mix,
                 class_num=class_num,
-                dtype=data_dtype)
+                dtype="float32")
 
             # build model
             # data_format should be assigned in arch-dict


### PR DESCRIPTION
背景：过去框架AMP在O2模式下，当OP支持低精度就会选择低精度的kernel，但这样的策略出现精度问题的风险较高。为保障训练精度，框架在2.5版本对AMP 策略进行了调整，即在O2模式下，仅当Op所有输入为低精度时才会选择低精度kernel，否则则采用FP32 Kernel（即promote的策略），因此可能会引起部分模型出现性能下降。

目前可以通过给auto_cast设置use_promote=False参数来回退到旧版本的O2策略，为了减少对模型配置的修改，本PR给PaddleClas添加该参数的设置功能，当前模型库默认设置为use_promote=False，使用的是旧版本的O2策略，以解决性能下降问题。

PaddlePaddle框架动态图下默认的行为是use_promote=True，未来新增的模型如果出现精度问题，可以尝试给模型配置中增加设置去进行调试。

框架PR：https://github.com/PaddlePaddle/Paddle/pull/53742