### PR TITLE
Toward Devkit Consistency

### DIFF
--- a/ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_small_x1_0.yaml
+++ b/ppcls/configs/ImageNet/MobileNetV3/MobileNetV3_small_x1_0.yaml
@@ -30,6 +30,7 @@ AMP:
 Arch:
   name: MobileNetV3_small_x1_0
   class_num: 1000
+  pretrained: True
  
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/PPHGNet/PPHGNet_small.yaml
+++ b/ppcls/configs/ImageNet/PPHGNet/PPHGNet_small.yaml
@@ -31,6 +31,7 @@ AMP:
 Arch:
   name: PPHGNet_small
   class_num: 1000
+  pretrained: True
  
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/PPHGNet/PPHGNet_tiny.yaml
+++ b/ppcls/configs/ImageNet/PPHGNet/PPHGNet_tiny.yaml
@@ -31,6 +31,7 @@ AMP:
 Arch:
   name: PPHGNet_tiny
   class_num: 1000
+  pretrained: True
  
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/PPLCNet/PPLCNet_x1_0.yaml
+++ b/ppcls/configs/ImageNet/PPLCNet/PPLCNet_x1_0.yaml
@@ -29,6 +29,7 @@ AMP:
 Arch:
   name: PPLCNet_x1_0
   class_num: 1000
+  pretrained: True
  
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/ResNet/ResNet50.yaml
+++ b/ppcls/configs/ImageNet/ResNet/ResNet50.yaml
@@ -32,6 +32,7 @@ AMP:
 Arch:
   name: ResNet50
   class_num: 1000
+  pretrained: True
  
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_base_patch4_window7_224.yaml
+++ b/ppcls/configs/ImageNet/SwinTransformer/SwinTransformer_base_patch4_window7_224.yaml
@@ -32,6 +32,7 @@ AMP:
 Arch:
   name: SwinTransformer_base_patch4_window7_224
   class_num: 1000
+  pretrained: True
  
 # loss function config for traing/eval process
 Loss:

--- a/ppcls/configs/slim/ClasModels_general_quantization.yaml
+++ b/ppcls/configs/slim/ClasModels_general_quantization.yaml
@@ -1,0 +1,5 @@
+# for quantizaiton or prune model
+Slim:
+  ## for prune
+  quant:
+    name: pact

--- a/ppcls/configs/slim/ClasModels_general_quantization.yaml
+++ b/ppcls/configs/slim/ClasModels_general_quantization.yaml
@@ -1,5 +1,0 @@
-# for quantizaiton or prune model
-Slim:
-  ## for prune
-  quant:
-    name: pact

--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -15,6 +15,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os
+import shutil
 import platform
 import paddle
 import paddle.distributed as dist
@@ -72,8 +73,7 @@ class Engine(object):
 
         # init logger
         self.output_dir = self.config['Global']['output_dir']
-        log_file = os.path.join(self.output_dir, self.config["Arch"]["name"],
-                                f"{mode}.log")
+        log_file = os.path.join(self.output_dir, f"{mode}.log")
         init_logger(log_file=log_file)
         print_config(config)
 
@@ -519,6 +519,10 @@ class Engine(object):
                                                           save_path + "_int8")
         else:
             paddle.jit.save(model, save_path)
+        if self.config["Global"].get("export_for_fd", False):
+            src_path = self.config["Global"]["infer_config_path"]
+            dst_path = os.path.join(self.config["Global"]["save_inference_dir"], 'inference.yml')
+            shutil.copy(src_path, dst_path)
         logger.info(
             f"Export succeeded! The inference model exported has been saved in \"{self.config['Global']['save_inference_dir']}\"."
         )

--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -94,7 +94,7 @@ class Engine(object):
         self.vdl_writer = None
         if self.config['Global'][
                 'use_visualdl'] and mode == "train" and dist.get_rank() == 0:
-            vdl_writer_path = os.path.join(self.output_dir, "vdl")
+            vdl_writer_path = self.output_dir
             if not os.path.exists(vdl_writer_path):
                 os.makedirs(vdl_writer_path)
             self.vdl_writer = LogWriter(logdir=vdl_writer_path)

--- a/ppcls/static/train.py
+++ b/ppcls/static/train.py
@@ -110,7 +110,7 @@ def main(args):
     # visualDL
     vdl_writer = None
     if global_config["use_visualdl"]:
-        vdl_dir = os.path.join(global_config["output_dir"], "vdl")
+        vdl_dir = global_config["output_dir"]
         vdl_writer = LogWriter(vdl_dir)
 
     # build dataloader

--- a/ppcls/utils/save_load.py
+++ b/ppcls/utils/save_load.py
@@ -163,7 +163,11 @@ def save_model(net,
     """
     if paddle.distributed.get_rank() != 0:
         return
-    model_path = os.path.join(model_path, model_name)
+
+    if prefix == 'best_model':
+        uapi_best_model_path = os.path.join(model_path, 'best_model')
+        _mkdir_if_not_exist(uapi_best_model_path)
+
     _mkdir_if_not_exist(model_path)
     model_path = os.path.join(model_path, prefix)
 
@@ -182,6 +186,11 @@ def save_model(net,
             paddle.save(s_params, model_path + "_student.pdparams")
 
     paddle.save(params_state_dict, model_path + ".pdparams")
+
+    if prefix == 'best_model':
+        uapi_best_model_path = os.path.join(uapi_best_model_path, 'model')
+        paddle.save(params_state_dict, uapi_best_model_path + ".pdparams")
+
     if ema is not None:
         paddle.save(ema.state_dict(), model_path + ".ema.pdparams")
     paddle.save([opt.state_dict() for opt in optimizer], model_path + ".pdopt")

--- a/ppcls/utils/save_load.py
+++ b/ppcls/utils/save_load.py
@@ -165,8 +165,8 @@ def save_model(net,
         return
 
     if prefix == 'best_model':
-        uapi_best_model_path = os.path.join(model_path, 'best_model')
-        _mkdir_if_not_exist(uapi_best_model_path)
+        best_model_path = os.path.join(model_path, 'best_model')
+        _mkdir_if_not_exist(best_model_path)
 
     _mkdir_if_not_exist(model_path)
     model_path = os.path.join(model_path, prefix)
@@ -188,8 +188,8 @@ def save_model(net,
     paddle.save(params_state_dict, model_path + ".pdparams")
 
     if prefix == 'best_model':
-        uapi_best_model_path = os.path.join(uapi_best_model_path, 'model')
-        paddle.save(params_state_dict, uapi_best_model_path + ".pdparams")
+        best_model_path = os.path.join(best_model_path, 'model')
+        paddle.save(params_state_dict, best_model_path + ".pdparams")
 
     if ema is not None:
         paddle.save(ema.state_dict(), model_path + ".ema.pdparams")


### PR DESCRIPTION
## 目标

修改代码以提升PaddleCV套件一致性，同时适配X项目。修改后，套件应满足如下一致性要求：

1. 将训练过程中最优（一般是验证集上精度最高）的模型权重存储在输出目录的`best_model`子目录中，文件命名为`model.pdparams`。与之相配套的优化器参数（如果存储的话）文件命名为`model.pdopt`，也存储在该目录中。
2. 支持将训练、验证过程中VisualDL产生的.log格式日志文件保存在输出目录中（无嵌套子目录）。
3. 套件根目录存在`requirements.txt`文件，指定使用套件基础功能需要的依赖。在套件根目录可通过`pip install .`或`pip install -e .`方式（至少其中一种）安装套件核心库。
4. 对于模型导出功能，默认支持或通过命令行选项/配置文件等手段支持导出为FD格式。『FD格式』的导出结果通常包含如下文件：
- `inference.pdiparams`：保存权重参数。
- `inference.pdiparams.info`：保存与参数有关的额外信息。
- `inference.pdmodel`：保存模型结构描述信息。
- （可选）`inference.yml`：预处理配置文件。

## 代码变动

1. 【一致性提升】【**不兼容升级**】使训练时检查点存储位置满足一致性要求1。
2. 【一致性提升】【**不兼容升级**】修改VisualDL日志存储位置以满足一致性要求2。
3. 【一致性提升】增加配置项`Global.export_for_fd`和`Global.infer_config_path`，前者作为开关控制是否将模型导出为FD格式，后者提供配置文件路径，以便模型导出时将该配置文件拷贝到导出目录作为`inference.yml`。
4. 【功能增强】修改`MobileNetV3_small_x1_0`等模型配置文件，指定加载预训练权重。

## 遗留问题

1. 对于代码变动1和2，**尚未更新相关文档**。若此PR合入，可能需要套件同学进行更新。
2. 由于代码变动1为不兼容升级，若此PR合入，套件RD和QA同学可能需要**更新测试脚本**。
3. 为减小不兼容升级带来的影响，本次改动未完全移除PaddleClas原有的对最优模型的存储逻辑。因此，输出目录中将存在model.pdparams的两份拷贝。后续需考虑继续优化，使最优模型只保留一份。
4. 目前`best_model`目录中尚未存储`model.pdopt`，尽管后者是可存储的。不过目前的实现也未违背一致性要求1。后续可考虑追加存储优化器参数。
