### PR TITLE
add 2 more custom devices intel_gpu and apple mps

### DIFF
--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -94,8 +94,9 @@ class Engine(object):
             self.vdl_writer = LogWriter(logdir=vdl_writer_path)
 
         # set device
-        assert self.config["Global"][
-            "device"] in ["cpu", "gpu", "xpu", "npu", "mlu"]
+        assert self.config["Global"]["device"] in [
+            "cpu", "gpu", "xpu", "npu", "mlu", "intel_gpu", "mps"
+        ]
         self.device = paddle.set_device(self.config["Global"]["device"])
         logger.info('train with paddle {} and device {}'.format(
             paddle.__version__, self.device))

--- a/ppcls/static/train.py
+++ b/ppcls/static/train.py
@@ -78,8 +78,9 @@ def main(args):
         fleet.init(is_collective=True)
 
     # assign the device
-    assert global_config[
-        "device"] in ["cpu", "gpu", "xpu", "npu", "mlu", "ascend"]
+    assert global_config["device"] in [
+        "cpu", "gpu", "xpu", "npu", "mlu", "ascend", "intel_gpu", "mps"
+    ]
     device = paddle.set_device(global_config["device"])
 
     # amp related config


### PR DESCRIPTION
in PaddleCustomDevice there are two new types of hw was supported, on is the Intel Data Center GPU and another is Apple MPS, so this pr aims to add those two kind of devices to paddleclas repo and prepare for some benchmark data base on this repo