### PR TITLE
[npu tipc] fix npu tipc scripts to reduce running time

### DIFF
--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -91,7 +91,7 @@ infer_value1=$(func_parser_value "${lines[50]}")
 if [ ! $epoch_num ]; then
     epoch_num=2
 fi
-if [[ $MODE = 'benchmark_train' ]]; then
+if [[ $MODE = 'benchmark_train' ]] || [[ $train_use_gpu_value = 'npu' ]]; then
     epoch_num=1
 fi
 

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -21,6 +21,15 @@ FILENAME=$1
 # change gpu to npu in tipc txt configs
 sed -i "s/Global.device:gpu/Global.device:npu/g" $FILENAME
 sed -i "s/Global.use_gpu/Global.use_npu/g" $FILENAME
+sed -i "s/Global.use_tensorrt:True|False/Global.use_tensorrt:False/g" $FILENAME
+sed -i "s/Global.save_interval=2/Global.save_interval=1/g" $FILENAME
+sed -i "s/-o Global.epochs:lite_train_lite_infer=2/-o Global.epochs:lite_train_lite_infer=1/g" $FILENAME
+
+modelname=$(echo $FILENAME | cut -d '/' -f4)
+if  [ $modelname == "PVTV2" ] || [ $modelname == "Twins" ] || [ $modelname == "SwinTransformer" ]; then
+    sed -i "s/gpu_list:0|0,1/gpu_list:0,1/g" $FILENAME
+fi
+
 dataline=`cat $FILENAME`
 
 # parser params


### PR DESCRIPTION
为了加快npu tipc benchmark时间，对于部分运行时间过长的模型，减少运行epoch/直接跑多卡