### PR TITLE
Update Pillow Version Limits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 prettytable
 ujson
 opencv-python<=4.6.0.66
-pillow>=9.0.0
+pillow==9.*
 tqdm
 PyYAML>=5.1
 visualdl>=2.2.0


### PR DESCRIPTION
由于新版Pillow库去除了`FreeTypeFont.getsize`接口，PaddleClas无法在Pillow>9.5.0以上版本工作。因此，在依赖列表中限制Pillow版本。参见：
https://github.com/XingangPan/DragGAN/issues/152