### PR TITLE
feat: add 2 weight functions in multi-label

### DIFF
--- a/ppcls/loss/dmlloss.py
+++ b/ppcls/loss/dmlloss.py
@@ -16,7 +16,7 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-from ppcls.loss.multilabelloss import ratio2weight_1
+from ppcls.loss.multilabelloss import ratio2weight_1, ratio2weight_2, ratio2weight_3
 
 
 class DMLLoss(nn.Layer):
@@ -24,7 +24,7 @@ class DMLLoss(nn.Layer):
     DMLLoss
     """
 
-    def __init__(self, act="softmax", sum_across_class_dim=False, eps=1e-12):
+    def __init__(self, act="softmax", sum_across_class_dim=False, eps=1e-12, weight_type=1, weight_alpha=0.1):
         super().__init__()
         if act is not None:
             assert act in ["softmax", "sigmoid"]
@@ -36,6 +36,8 @@ class DMLLoss(nn.Layer):
             self.act = None
         self.eps = eps
         self.sum_across_class_dim = sum_across_class_dim
+        self.weight_type = weight_type
+        self.weight_alpha = weight_alpha
 
     def _kldiv(self, x, target):
         class_num = x.shape[-1]
@@ -54,7 +56,15 @@ class DMLLoss(nn.Layer):
         if gt_label is not None:
             gt_label, label_ratio = gt_label[:, 0, :], gt_label[:, 1, :]
             targets_mask = paddle.cast(gt_label > 0.5, 'float32')
-            weight = ratio2weight(targets_mask, paddle.to_tensor(label_ratio))
+            if self.weight_type == 2:
+                weight = ratio2weight_2(
+                    targets_mask, paddle.to_tensor(label_ratio))
+            elif self.weight_type == 3:
+                weight = ratio2weight_3(
+                    targets_mask, paddle.to_tensor(label_ratio), self.weight_alpha)
+            else:
+                weight = ratio2weight_1(
+                    targets_mask, paddle.to_tensor(label_ratio))
             weight = weight * (gt_label > -1)
             loss = loss * weight
 

--- a/ppcls/loss/dmlloss.py
+++ b/ppcls/loss/dmlloss.py
@@ -16,7 +16,7 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-from ppcls.loss.multilabelloss import ratio2weight
+from ppcls.loss.multilabelloss import ratio2weight_1
 
 
 class DMLLoss(nn.Layer):

--- a/ppcls/loss/multilabelloss.py
+++ b/ppcls/loss/multilabelloss.py
@@ -3,10 +3,62 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 
 
-def ratio2weight(targets, ratio):
+def ratio2weight_1(targets, ratio):
+    '''
+    Math formula:
+    ```
+    w_j = y_{ij} * e^{1 - r_j} + (1 - {y_ij}) * e^{r_j}
+    ```
+    REF: https://arxiv.org/abs/2107.03576v2
+    '''
+
     pos_weights = targets * (1. - ratio)
     neg_weights = (1. - targets) * ratio
     weights = paddle.exp(neg_weights + pos_weights)
+
+    # for RAP dataloader, targets element may be 2, with or without smooth, some element must great than 1
+    weights = weights - weights * (targets > 1)
+
+    return weights
+
+
+def ratio2weight_2(targets, ratio):
+    '''
+    Math formula:
+    ```
+    w_j = y_{ij} * \sqrt{\frac{1}{2 * r_j}} + (1 - {y_ij}) * \sqrt{\frac{1}{2 * (1 - r_j)}}
+    ```
+    REF: https://arxiv.org/abs/2107.03576v2
+    '''
+
+    pos_weights = targets * ratio
+    neg_weights = (1. - targets) * (1 - ratio)
+    weights = paddle.sqrt(0.5 * paddle.reciprocal(neg_weights + pos_weights))
+
+    # for RAP dataloader, targets element may be 2, with or without smooth, some element must great than 1
+    weights = weights - weights * (targets > 1)
+
+    return weights
+
+
+def ratio2weight_3(targets, ratio, alpha):
+    '''
+    Math formula:
+    ```
+    w_j = y_{ij} * \frac{(1/r_j)^\alpha}{(1/r_j)^\alpha + (1/(1 - r_j))^\alpha} 
+          + (1 - {y_ij}) * \frac{(1/(1 - r_j))^\alpha}{(1/r_j)^\alpha + (1/(1 - r_j))^\alpha} 
+    ```
+    REF: https://arxiv.org/abs/2107.03576v2
+    '''
+
+    pos_weights = targets * ratio
+    neg_weights = (1. - targets) * (1 - ratio)
+    combined_weights = pos_weights + neg_weights
+    weights = paddle.divide(
+        paddle.reciprocal(paddle.pow(combined_weights, alpha)),
+        paddle.reciprocal(paddle.pow(combined_weights, alpha)) +
+        paddle.reciprocal((paddle.pow(1 - combined_weights, alpha)))
+    )
 
     # for RAP dataloader, targets element may be 2, with or without smooth, some element must great than 1
     weights = weights - weights * (targets > 1)
@@ -19,11 +71,13 @@ class MultiLabelLoss(nn.Layer):
     Multi-label loss
     """
 
-    def __init__(self, epsilon=None, size_sum=False, weight_ratio=False):
+    def __init__(self, epsilon=None, size_sum=False, weight_type=1, weight_ratio=False, weight_alpha=False):
         super().__init__()
         if epsilon is not None and (epsilon <= 0 or epsilon >= 1):
             epsilon = None
         self.epsilon = epsilon
+        self.weight_type = weight_type
+        self.weight_alpha = weight_alpha
         self.weight_ratio = weight_ratio
         self.size_sum = size_sum
 
@@ -46,7 +100,15 @@ class MultiLabelLoss(nn.Layer):
 
         if self.weight_ratio:
             targets_mask = paddle.cast(target > 0.5, 'float32')
-            weight = ratio2weight(targets_mask, paddle.to_tensor(label_ratio))
+            if self.weight_type == 2:
+                weight = ratio2weight_2(
+                    targets_mask, paddle.to_tensor(label_ratio))
+            elif self.weight_type == 3:
+                weight = ratio2weight_3(targets_mask, paddle.to_tensor(
+                    label_ratio), self.weight_alpha)
+            else:
+                weight = ratio2weight_1(
+                    targets_mask, paddle.to_tensor(label_ratio))
             weight = weight * (target > -1)
             cost = cost * weight
 

--- a/ppcls/loss/multilabelloss.py
+++ b/ppcls/loss/multilabelloss.py
@@ -156,7 +156,7 @@ class MultiLabelAsymmetricLoss(nn.Layer):
         # Asymmetric Clipping and Basic CE calculation
         if self.clip and self.clip > 0:
             pt = (1 - pred_sigmoid + self.clip).clip(max=1) \
-                * (1 - target) + pred_sigmoid * target
+                 * (1 - target) + pred_sigmoid * target
         else:
             pt = (1 - pred_sigmoid) * (1 - target) + pred_sigmoid * target
 

--- a/ppcls/loss/multilabelloss.py
+++ b/ppcls/loss/multilabelloss.py
@@ -11,7 +11,6 @@ def ratio2weight_1(targets, ratio):
     ```
     REF: https://arxiv.org/abs/2107.03576v2
     '''
-
     pos_weights = targets * (1. - ratio)
     neg_weights = (1. - targets) * ratio
     weights = paddle.exp(neg_weights + pos_weights)
@@ -71,14 +70,14 @@ class MultiLabelLoss(nn.Layer):
     Multi-label loss
     """
 
-    def __init__(self, epsilon=None, size_sum=False, weight_type=1, weight_ratio=False, weight_alpha=False):
+    def __init__(self, epsilon=None, size_sum=False, weight_ratio=False, weight_type=1, weight_alpha=0.1):
         super().__init__()
         if epsilon is not None and (epsilon <= 0 or epsilon >= 1):
             epsilon = None
         self.epsilon = epsilon
+        self.weight_ratio = weight_ratio
         self.weight_type = weight_type
         self.weight_alpha = weight_alpha
-        self.weight_ratio = weight_ratio
         self.size_sum = size_sum
 
     def _labelsmoothing(self, target, class_num):


### PR DESCRIPTION
根据 https://github.com/PaddlePaddle/PaddleClas/issues/2951 新增两个 ratio2weight 函数。代码里延续论文中的命名，所以原 `ratios2weight` 改为 `ratios2weight_1`。

Type 3 示例：

```
# loss function config for traing/eval process
Loss:
  Train:
    - MultiLabelLoss:
        weight: 1.0
        weight_type: 3 
        weight_alpha: 1 # float
        weight_ratio: True
        size_sum: True
  Eval:
    - MultiLabelLoss:
        weight: 1.0
        weight_type: 3 
        weight_alpha: 1 # float
        weight_ratio: True
        size_sum: True
```

Type 2/1 示例：

```
# loss function config for traing/eval process
Loss:
  Train:
    - MultiLabelLoss:
        weight: 1.0
        weight_type: 2 
        weight_ratio: True
        size_sum: True
  Eval:
    - MultiLabelLoss:
        weight: 1.0
        weight_type: 2
        weight_ratio: True
        size_sum: True
```

但是 https://github.com/PaddlePaddle/PaddleClas/blob/release/2.5/ppcls/loss/dmlloss.py 中 import 了 `ratio2weight` 这个函数，目前的解决方案是在 dmlloss 中开启 weight_type 和 weight_alpha 这两个参数，与 multilabelloss 中保持一致，然后计算对应的 loss。