### PR TITLE
[TIPC]fix python version in tipc

### DIFF
--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -27,6 +27,7 @@ sed -i "s/-o Global.epochs:lite_train_lite_infer=2/-o Global.epochs:lite_train_l
 sed -i "s/enable_mkldnn:True|False/enable_mkldnn:False/g" $FILENAME
 # python has been updated to version 3.9 for npu backend
 sed -i "s/python3.7/python3.9/g" $FILENAME
+sed -i "s/python3.10/python3.9/g" $FILENAME
 
 modelname=$(echo $FILENAME | cut -d '/' -f3)
 if  [ $modelname == "PVTV2" ] || [ $modelname == "Twins" ] || [ $modelname == "SwinTransformer" ]; then

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -27,6 +27,7 @@ sed -i "s/-o Global.epochs:lite_train_lite_infer=2/-o Global.epochs:lite_train_l
 sed -i "s/enable_mkldnn:True|False/enable_mkldnn:False/g" $FILENAME
 # python has been updated to version 3.9 for xpu backend
 sed -i "s/python3.7/python3.9/g" $FILENAME
+sed -i "s/python3.10/python3.9/g" $FILENAME
 
 modelname=$(echo $FILENAME | cut -d '/' -f3)
 if  [ $modelname == "PVTV2" ] || [ $modelname == "Twins" ] || [ $modelname == "SwinTransformer" ]; then


### PR DESCRIPTION
目前npu、xpu TIPC使用python版本为3.9，部分TIPC模型默认使用的是python3.10，因此在tipc脚本中修改这些模型的配置文件中的python版本。