### PR TITLE
[cherry-pick]cherry-pick tipc scripts update and fix np.int error

### DIFF
--- a/ppcls/data/preprocess/ops/autoaugment.py
+++ b/ppcls/data/preprocess/ops/autoaugment.py
@@ -204,7 +204,7 @@ class SubPolicy(object):
             "translateY": np.linspace(0, 150 / 331, 10),
             "rotate": np.linspace(0, 30, 10),
             "color": np.linspace(0.0, 0.9, 10),
-            "posterize": np.round(np.linspace(8, 4, 10), 0).astype(np.int),
+            "posterize": np.round(np.linspace(8, 4, 10), 0).astype(np.int_),
             "solarize": np.linspace(256, 0, 10),
             "contrast": np.linspace(0.0, 0.9, 10),
             "sharpness": np.linspace(0.0, 0.9, 10),

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -259,9 +259,9 @@ else
                 if [ ${#gpu} -le 2 ]; then # train with cpu or single gpu
                     cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} "
                 elif [ ${#ips} -le 15 ]; then # train with multi-gpu
-                    cmd="${python} -m paddle.distributed.launch --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1}"
+                    cmd="${python} -m paddle.distributed.launch --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1}"
                 else # train with multi-machine
-                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1}"
+                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1}"
                 fi
                 # run train
                 eval "unset CUDA_VISIBLE_DEVICES"

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -24,10 +24,12 @@ sed -i "s/Global.use_gpu/Global.use_npu/g" $FILENAME
 sed -i "s/Global.use_tensorrt:True|False/Global.use_tensorrt:False/g" $FILENAME
 sed -i "s/Global.save_interval=2/Global.save_interval=1/g" $FILENAME
 sed -i "s/-o Global.epochs:lite_train_lite_infer=2/-o Global.epochs:lite_train_lite_infer=1/g" $FILENAME
+sed -i "s/enable_mkldnn:True|False/enable_mkldnn:False/g" $FILENAME
 # python has been updated to version 3.9 for npu backend
 sed -i "s/python3.7/python3.9/g" $FILENAME
+sed -i "s/python3.10/python3.9/g" $FILENAME
 
-modelname=$(echo $FILENAME | cut -d '/' -f4)
+modelname=$(echo $FILENAME | cut -d '/' -f3)
 if  [ $modelname == "PVTV2" ] || [ $modelname == "Twins" ] || [ $modelname == "SwinTransformer" ]; then
     sed -i "s/gpu_list:0|0,1/gpu_list:0,1/g" $FILENAME
 fi
@@ -50,6 +52,9 @@ grep -n 'tools/.*yaml' $FILENAME  | cut -d ":" -f 1 \
     trainer_config=$(func_parser_config ${train_cmd})
     sed -i 's/device: gpu/device: npu/g' "$REPO_ROOT_PATH/$trainer_config"
 done
+
+# change gpu to npu in execution script
+sed -i "s/\"gpu\"/\"npu\"/g" test_tipc/test_train_inference_python.sh
 
 # pass parameters to test_train_inference_python.sh
 cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -21,6 +21,19 @@ FILENAME=$1
 # change gpu to xpu in tipc txt configs
 sed -i "s/Global.device:gpu/Global.device:xpu/g" $FILENAME
 sed -i "s/Global.use_gpu/Global.use_xpu/g" $FILENAME
+sed -i "s/Global.use_tensorrt:True|False/Global.use_tensorrt:False/g" $FILENAME
+sed -i "s/Global.save_interval=2/Global.save_interval=1/g" $FILENAME
+sed -i "s/-o Global.epochs:lite_train_lite_infer=2/-o Global.epochs:lite_train_lite_infer=1/g" $FILENAME
+sed -i "s/enable_mkldnn:True|False/enable_mkldnn:False/g" $FILENAME
+# python has been updated to version 3.9 for xpu backend
+sed -i "s/python3.7/python3.9/g" $FILENAME
+sed -i "s/python3.10/python3.9/g" $FILENAME
+
+modelname=$(echo $FILENAME | cut -d '/' -f3)
+if  [ $modelname == "PVTV2" ] || [ $modelname == "Twins" ] || [ $modelname == "SwinTransformer" ]; then
+    sed -i "s/gpu_list:0|0,1/gpu_list:0,1/g" $FILENAME
+fi
+
 dataline=`cat $FILENAME`
 
 # parser params
@@ -39,6 +52,11 @@ grep -n 'tools/.*yaml' $FILENAME  | cut -d ":" -f 1 \
     trainer_config=$(func_parser_config ${train_cmd})
     sed -i 's/device: gpu/device: xpu/g' "$REPO_ROOT_PATH/$trainer_config"
 done
+
+# change gpu to xpu in execution script
+sed -i "s/\"gpu\"/\"xpu\"/g" test_tipc/test_train_inference_python.sh
+sed -i "s/\${model_name}\/train.log/train.log/g" test_tipc/test_train_inference_python.sh
+sed -i "s/\${model_name}\/\${train_model_name}/\${train_model_name}/g" test_tipc/test_train_inference_python.sh
 
 # pass parameters to test_train_inference_python.sh
 cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"


### PR DESCRIPTION
1.将develop分支的tipc脚本改动cherry-pick到release2.5分支
2.修复np.int报错的bug，报错如下：
<img width="1160" alt="600f534fc92db3d83cd2754cb06c6cf5" src="https://github.com/PaddlePaddle/PaddleClas/assets/50285351/f8ca662f-138c-4d64-96d0-08603f182dcd">
