### PR TITLE
【benchmark】add max_mem_reserved for benchmark 

### DIFF
--- a/ppcls/engine/train/utils.py
+++ b/ppcls/engine/train/utils.py
@@ -60,8 +60,8 @@ def log_info(trainer, batch_size, epoch_id, iter_id):
         (trainer.config["Global"]["epochs"] - epoch_id + 1) *
         trainer.iter_per_epoch - iter_id) * trainer.time_info["batch_cost"].avg
     eta_msg = "eta: {:s}".format(str(datetime.timedelta(seconds=int(eta_sec))))
-    max_mem_reserved_msg = f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()}"
-    max_mem_allocated_msg = f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()}"
+    max_mem_reserved_msg = f"max_mem_reserved: {paddle.device.cuda.max_memory_reserved()} B"
+    max_mem_allocated_msg = f"max_mem_allocated: {paddle.device.cuda.max_memory_allocated()} B"
     logger.info(
         f"[Train][Epoch {epoch_id}/{global_epochs}][Iter: {iter_id}/{trainer.iter_per_epoch}]{lr_msg}, {metric_msg}, {time_msg}, {ips_msg}, {eta_msg}, {max_mem_reserved_msg}, {max_mem_allocated_msg}"
     )

--- a/test_tipc/static/ResNet50/benchmark_common/run_benchmark.sh
+++ b/test_tipc/static/ResNet50/benchmark_common/run_benchmark.sh
@@ -55,7 +55,7 @@ function _train(){
 	        train_cmd="python ppcls/static/train.py ${train_cmd}"
         else
             rm -rf ./mylog
-            train_cmd="python -m paddle.distributed.launch --gpus 0,1,2,3,4,5,6,7 ppcls/static/train.py ${train_cmd}"
+            train_cmd="python -m paddle.distributed.launch --gpus 0,1,2,3,4,5,6,7 ppcls/static/train.py ${train_cmd} -o Global.log_ranks=0,1,2,3,4,5,6,7"
         fi
         ;;
     DP1-MP1-PP1)  echo "run run_mode: DP1-MP1-PP1" ;;

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -262,12 +262,13 @@ else
                 # fi
 
                 set_save_model=$(func_set_params "${save_model_key}" "${save_log}")
+                log_rank="-o Global.log_ranks=0,1,2,3,4,5,6,7"
                 if [ ${#gpu} -le 2 ]; then # train with cpu or single gpu
                     cmd="${python} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} "
                 elif [ ${#ips} -le 15 ]; then # train with multi-gpu
-                    cmd="${python} -m paddle.distributed.launch --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1}"
+                    cmd="${python} -m paddle.distributed.launch --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${log_rank}"
                 else # train with multi-machine
-                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1}"
+                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1} ${log_rank}"
                 fi
                 # run train
                 # export FLAGS_cudnn_deterministic=True


### PR DESCRIPTION
训练benchmark 使用 API paddle.device.cuda.max_memory_reserved() 收集模型训练时的显存占用，因此本PR 修改 benchmark 打印日志部分开启多张卡打印日志参数
