### PR TITLE
Different label shape may cause problems putting into bceloss func.

### DIFF
--- a/ppcls/loss/multilabelloss.py
+++ b/ppcls/loss/multilabelloss.py
@@ -59,6 +59,8 @@ class MultiLabelLoss(nn.Layer):
         if isinstance(x, dict):
             x = x["logits"]
         class_num = x.shape[-1]
+        target = F.one_hot(target, num_classes=class_num)
+        target = paddle.reshape(target, shape=[-1, class_num])
         loss = self._binary_crossentropy(x, target, class_num)
         loss = loss.mean()
         return {"MultiLabelLoss": loss}

--- a/ppcls/loss/multilabelloss.py
+++ b/ppcls/loss/multilabelloss.py
@@ -59,8 +59,9 @@ class MultiLabelLoss(nn.Layer):
         if isinstance(x, dict):
             x = x["logits"]
         class_num = x.shape[-1]
-        target = F.one_hot(target, num_classes=class_num)
-        target = paddle.reshape(target, shape=[-1, class_num])
+        if target.shape[-1] == 1:
+            target = F.one_hot(target, num_classes=class_num)
+            target = paddle.reshape(target, shape=[-1, class_num])
         loss = self._binary_crossentropy(x, target, class_num)
         loss = loss.mean()
         return {"MultiLabelLoss": loss}


### PR DESCRIPTION
When label.shape is [batch, 1], bceloss function may not accept, change into the one hot version like [batch, class_num].