### PR TITLE
refine batch_cost stat

### DIFF
--- a/ppcls/engine/train/utils.py
+++ b/ppcls/engine/train/utils.py
@@ -72,7 +72,8 @@ def log_info(trainer, batch_size, epoch_id, iter_id):
     logger.info(
         f"[Train][Epoch {epoch_id}/{global_epochs}][Iter: {iter_id}/{trainer.iter_per_epoch}]{lr_msg}, {metric_msg}, {time_msg}, {ips_msg}, {eta_msg}{max_mem_msg}"
     )
-    trainer.time_info[key].reset() for key in trainer.time_info
+    for key in trainer.time_info:
+        trainer.time_info[key].reset()
 
     for i, lr in enumerate(trainer.lr_sch):
         logger.scaler(

--- a/ppcls/engine/train/utils.py
+++ b/ppcls/engine/train/utils.py
@@ -72,7 +72,7 @@ def log_info(trainer, batch_size, epoch_id, iter_id):
     logger.info(
         f"[Train][Epoch {epoch_id}/{global_epochs}][Iter: {iter_id}/{trainer.iter_per_epoch}]{lr_msg}, {metric_msg}, {time_msg}, {ips_msg}, {eta_msg}{max_mem_msg}"
     )
-    trainer.time_info["batch_cost"].reset()
+    trainer.time_info[key].reset() for key in trainer.time_info
 
     for i, lr in enumerate(trainer.lr_sch):
         logger.scaler(

--- a/ppcls/engine/train/utils.py
+++ b/ppcls/engine/train/utils.py
@@ -72,6 +72,7 @@ def log_info(trainer, batch_size, epoch_id, iter_id):
     logger.info(
         f"[Train][Epoch {epoch_id}/{global_epochs}][Iter: {iter_id}/{trainer.iter_per_epoch}]{lr_msg}, {metric_msg}, {time_msg}, {ips_msg}, {eta_msg}{max_mem_msg}"
     )
+    trainer.time_info["batch_cost"].reset()
 
     for i, lr in enumerate(trainer.lr_sch):
         logger.scaler(


### PR DESCRIPTION
AverageMeter,用于统计上次IPS打印，到本次IPS打印的时间统计数据。在每次log_info后，需要reset。否则统计的IPS是错误的。