### PR TITLE
refine drop_path

### DIFF
--- a/ppcls/arch/backbone/model_zoo/vision_transformer.py
+++ b/ppcls/arch/backbone/model_zoo/vision_transformer.py
@@ -60,7 +60,7 @@ def drop_path(x, drop_prob=0., training=False):
     """
     if drop_prob == 0. or not training:
         return x
-    keep_prob = paddle.to_tensor(1 - drop_prob, dtype=x.dtype)
+    keep_prob = paddle.full(shape=[], fill_value=1 - drop_prob, dtype=x.dtype)
     shape = (x.shape[0], ) + (1, ) * (x.ndim - 1)
     random_tensor = keep_prob + paddle.rand(shape).astype(x.dtype)
     random_tensor = paddle.floor(random_tensor)  # binarize


### PR DESCRIPTION
drop_path将1个float转换为Tensor，使用了to_tensor。to_tensor会使用阻塞式的H2D拷贝，导致Python端阻塞，进而导致无法预加载kernel，导致GPU利用率低。
改为full可以解决这个问题。