### PR TITLE
refine benchmakr dali config

### DIFF
--- a/test_tipc/configs/ResNet/ResNet50_NHWC_bs256_dali_train_infer_python.txt
+++ b/test_tipc/configs/ResNet/ResNet50_NHWC_bs256_dali_train_infer_python.txt
@@ -55,7 +55,7 @@ batch_size:256
 fp_items:fp16
 epoch:1
 model_type:norm_train|to_static_train
-num_workers:32
+num_workers:8
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
 ===========================infer_benchmark_params==========================

--- a/test_tipc/configs/ResNet/ResNet50_bs256_dali_train_infer_python.txt
+++ b/test_tipc/configs/ResNet/ResNet50_bs256_dali_train_infer_python.txt
@@ -55,7 +55,7 @@ batch_size:256
 fp_items:fp16
 epoch:1
 model_type:norm_train|to_static_train
-num_workers:32
+num_workers:8
 --profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
 flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096
 ===========================infer_benchmark_params==========================


### PR DESCRIPTION
两个Benchmark dali的配置，num_workers不是最优的，导致8卡运行时，dali线程和主线程在CUDA API调用上冲突，造成模型运行慢。
修复后，PaddleClas_ResNet50_NHWC_dali_bs256_fp16_DP_N1C8本地测试：
在PR https://github.com/PaddlePaddle/Paddle/pull/64211 前，IPS=7937，PR后IPS为7999。