### PR TITLE
Use `inspect.getfullargspec` instead of deprecated `inspect.getargspec`

### DIFF
--- a/ppcls/optimizer/optimizer.py
+++ b/ppcls/optimizer/optimizer.py
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import inspect
-# for python3.11
-if not hasattr(inspect, 'getargspec'):
-    inspect.getargspec = inspect.getfullargspec
-
 import paddle
 from paddle import optimizer as optim
 from ppcls.utils import logger
@@ -66,7 +58,7 @@ class SGD(object):
         # model_list is None in static graph
         parameters = sum([m.parameters() for m in model_list],
                          []) if model_list else None
-        argspec = inspect.getargspec(optim.SGD.__init__).args
+        argspec = inspect.getfullargspec(optim.SGD.__init__).args
         if 'multi_precision' in argspec:
             opt = optim.SGD(learning_rate=self.learning_rate,
                             parameters=parameters,


### PR DESCRIPTION
```
2024-06-19 16:12:06 2024-06-19 16:12:06,931 - DDDivano - [INFO] - [2024/06/19 08:12:06] ppcls INFO: Successfully to apply @to_static with specs: [InputSpec(shape=(-1, 3, 224, 224), dtype=paddle.float32, name=None, stop_gradient=True)]
2024-06-19 16:12:07 2024-06-19 16:12:06,934 - DDDivano - [ERROR] - Traceback (most recent call last):
2024-06-19 16:12:07 2024-06-19 16:12:06,934 - DDDivano - [ERROR] -   File "/paddle/jelly/PaddleClas/tools/train.py", line 31, in <module>
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -     engine = Engine(config, mode="train")
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -   File "/paddle/jelly/PaddleClas/ppcls/engine/engine.py", line 209, in __init__
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -     self.optimizer, self.lr_sch = build_optimizer(
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -   File "/paddle/jelly/PaddleClas/ppcls/optimizer/__init__.py", line 123, in build_optimizer
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -     optim = getattr(optimizer, optim_name)(
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -   File "/paddle/jelly/PaddleClas/ppcls/optimizer/optimizer.py", line 64, in __call__
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -     argspec = inspect.getargspec(optim.SGD.__init__).args
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -   File "/usr/lib/python3.10/inspect.py", line 1237, in getargspec
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] -     raise ValueError("Function has keyword-only parameters or annotations"
2024-06-19 16:12:07 2024-06-19 16:12:06,935 - DDDivano - [ERROR] - ValueError: Function has keyword-only parameters or annotations, use inspect.signature() API which can support them
```

`inspect.getargspec` 不支持类型提示和 kw-only arg，框架最近在推类型提示，`SGD` 也已经添加，这就导致调用 `inspect.getargspec` 时挂掉了

`inspect.getargspec` 在 Python 3.0 就弃用了，可以使用功能更加全面的 `inspect.getfullargspec` 替代，也是支持类型提示的

顺带清理掉无用的 `from __future__ import xxx`，这些确定无用，除非还支持 Python 2.x

cc @HydrogenSulfate