### PR TITLE
Mark some models as rec model in yaml

### DIFF
--- a/ppcls/configs/DeepHash/DCH.yaml
+++ b/ppcls/configs/DeepHash/DCH.yaml
@@ -26,6 +26,7 @@ Arch:
   name: RecModel
   infer_output_key: features
   infer_add_softmax: False
+  is_rec: True
 
   Backbone:
     name: AlexNet

--- a/ppcls/configs/DeepHash/DSHSD.yaml
+++ b/ppcls/configs/DeepHash/DSHSD.yaml
@@ -26,6 +26,7 @@ Arch:
   name: RecModel
   infer_output_key:  features
   infer_add_softmax: False
+  is_rec: True
 
   Backbone:
     name: AlexNet

--- a/ppcls/configs/DeepHash/LCDSH.yaml
+++ b/ppcls/configs/DeepHash/LCDSH.yaml
@@ -26,6 +26,7 @@ Arch:
   name: RecModel
   infer_output_key: features
   infer_add_softmax: False
+  is_rec: True
 
   Backbone:
     name: AlexNet


### PR DESCRIPTION
将三个 DeepHash 下的模型标记为 Rec model，因为它们已经使用了 RecModel，但 `engine.is_rec` 却是 False，会和 #3176 一样引发动转静传值数量和 input spec 数量不匹配