### PR TITLE
Add missing label for classification model in eval mode

### DIFF
--- a/ppcls/engine/evaluation/classification.py
+++ b/ppcls/engine/evaluation/classification.py
@@ -56,7 +56,7 @@ def classification_eval(engine, epoch_id=0):
 
         # image input
         with engine.auto_cast(is_eval=True):
-            out = engine.model(batch[0])
+            out = engine.model(batch[0], batch[1])
 
         # just for DistributedBatchSampler issue: repeat sampling
         current_samples = batch_size * paddle.distributed.get_world_size()


### PR DESCRIPTION
修复 AST 动转静下，eval mode 下不传 label 会导致和 input spec 不一致而挂掉的问题

同 #3176，只不过该 PR 修改了 `retrieval`，漏掉了 `classification`