### PR TITLE
python3.13依赖问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 prettytable
 ujson
-opencv-python<=4.6.0.66
+opencv-python<=4.6.0.66; python_version<"3.13"
+opencv-python>=4.10.0.84; python_version>="3.13"
 pillow>=9.0.0
 tqdm
 PyYAML>=5.1
@@ -10,5 +11,6 @@ scikit-learn>=0.21.0
 gast==0.3.3
 faiss-cpu
 easydict
-numpy==1.24.4
+numpy==1.24.4; python_version<"3.13"
+numpy>=2.1.0; python_version>="3.13"
 


### PR DESCRIPTION
过低的Numpy版本会试图使用pkgutil当中已经deprecated的属性；
更新Numpy版本之后，旧opencv不再兼容，需要同步升级