### PR TITLE
remove max inplace grad add

### DIFF
--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -645,7 +645,7 @@ class Engine(object):
             self.auto_cast = AutoCast(use_amp)
             self.scaler = build_scaler(use_amp)
         else:
-            AMP_RELATED_FLAGS_SETTING = {'FLAGS_max_inplace_grad_add': 8, }
+            AMP_RELATED_FLAGS_SETTING = {}
             if paddle.is_compiled_with_cuda():
                 AMP_RELATED_FLAGS_SETTING.update({
                     'FLAGS_cudnn_batchnorm_spatial_persistent': 1

--- a/ppcls/static/train.py
+++ b/ppcls/static/train.py
@@ -104,7 +104,6 @@ def main(args):
             'FLAGS_cudnn_exhaustive_search': 1,
             'FLAGS_conv_workspace_size_limit': 1500,
             'FLAGS_cudnn_batchnorm_spatial_persistent': 1,
-            'FLAGS_max_inplace_grad_add': 8,
         }
         os.environ['FLAGS_cudnn_batchnorm_spatial_persistent'] = '1'
         paddle.set_flags(AMP_RELATED_FLAGS_SETTING)


### PR DESCRIPTION
移除FLAGS_max_inplace_grad_add的配置，这个max inplace grad add当前基于inplace的逻辑实现的，cinn不容易处理（开启编译器之后，部分任务性能会差距10%），暂时移除该配置，该配置仅影响动转静之后的性能