### PR TITLE
Fix: Resolve issue with unsuccessful dynamic-to-static conversion

### DIFF
--- a/ppcls/engine/engine.py
+++ b/ppcls/engine/engine.py
@@ -236,8 +236,6 @@ class Engine(object):
 
         # build model
         self.model = build_model(self.config, self.mode)
-        # set @to_static for benchmark, skip this by default.
-        apply_to_static(self.config, self.model, is_rec=self.is_rec)
 
         # load_pretrain
         if self.config["Global"]["pretrained_model"] is not None:
@@ -259,6 +257,9 @@ class Engine(object):
         if self.ema:
             self.model_ema = ExponentialMovingAverage(
                 self.model, self.config['EMA'].get("decay", 0.9999))
+
+        # set @to_static for benchmark, skip this by default.
+        apply_to_static(self.config, self.model, is_rec=self.is_rec)
 
         # check the gpu num
         world_size = dist.get_world_size()


### PR DESCRIPTION
The deep copy of model in EMA implementation prevents successful conversion from dynamic to static graph, causing fallback to dynamic graph execution. This PR resolves the issue by adjusting the execution order of EMA and to_static conversion.