### PR TITLE
Fix ImportError: attempted relative import with no known parent package in editable install modeFix ImportError in editable install mode. When installing via pip ins…

### DIFF
--- a/paddleclas.py
+++ b/paddleclas.py
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if not __package__:
+    from os.path import dirname, abspath
+    __path__ = [dirname(abspath(__file__))]
+    __package__ = 'paddleclas'
+    import sys
+    _m = sys.modules['paddleclas']
+    _m.__path__ = __path__
+    _m.__package__ = __package__
+
 import os
 from typing import Union, Generator
 import argparse


### PR DESCRIPTION
## Problem
When PaddleClas is installed via `pip install -e .` (editable/development mode),
`paddleclas.py` is loaded as a top-level module with `__package__` set to `''`,
causing all relative imports to fail:
**ImportError: attempted relative import with no known parent package**

This affects users who integrate PaddleClas as a dependency of PaddleX and
need editable installs for development workflows.

## Solution
Add a guard at the top of `paddleclas.py` that checks if `__package__` is
falsy (empty string or None), and if so, configures `__path__` and
`__package__` to make Python treat the file as a package.

This has zero impact on normal installations (where `__package__` is already
correctly set by setuptools).

## Testing
- `pip install .` → works as before ✅
- `pip install -e .` + `import paddleclas` → now works ✅
