### PR TITLE
新增mambavision模型

### DIFF
--- a/docs/zh_CN/models/ImageNet1k/MambaVision.md
+++ b/docs/zh_CN/models/ImageNet1k/MambaVision.md
@@ -1,0 +1,84 @@
+# MambaVision
+
+## 1. 模型介绍
+
+MambaVision 是 NVIDIA 提出的分层视觉骨干网络，在统一架构中结合卷积、自注意力与 Mamba 状态空间混合器。浅层卷积用于提取局部视觉特征，深层 Mamba 和 Attention Block 用于建模长程依赖。
+
+- 论文：[MambaVision: A Hybrid Mamba-Transformer Vision Backbone](https://arxiv.org/abs/2407.08083)
+- 官方实现：[NVlabs/MambaVision](https://github.com/NVlabs/MambaVision)
+- PaddlePaddle 权重：[AI Studio MambaVision 模型空间](https://aistudio.baidu.com/modelsdetail/51615)
+
+本实现提供 11 个 MambaVision 分类模型入口及对应的 ImageNet-1K 训练、评估和推理配置。模型名称中的 `21K` 表示上游预训练数据来源，当前发布的权重均使用 1,000 类分类头。
+
+## 2. 模型与权重
+
+| PaddleClas 名称 | 配置 | 输入尺寸 | 参数量(M) | Paddle Top-1 / Top-5 | 权重文件 |
+| --- | --- | ---: | ---: | ---: | --- |
+| `MambaVision_T` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml) | 224 | 31.8 | 82.176% / 96.172% | `mambavision_tiny_1k.pdparams` |
+| `MambaVision_T2` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_T2.yaml) | 224 | 35.1 | 82.636% / 96.272% | `mambavision_tiny2_1k.pdparams` |
+| `MambaVision_S` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_S.yaml) | 224 | 50.1 | 83.232% / 96.502% | `mambavision_small_1k.pdparams` |
+| `MambaVision_B` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_B.yaml) | 224 | 97.7 | 84.204% / 96.848% | `mambavision_base_1k.pdparams` |
+| `MambaVision_B_21K` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_B_21K.yaml) | 224 | 97.7 | 84.876% / 97.478% | `mambavision_base_21k.pdparams` |
+| `MambaVision_L` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_L.yaml) | 224 | 227.9 | 84.954% / 97.078% | `mambavision_large_1k.pdparams` |
+| `MambaVision_L_21K` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_L_21K.yaml) | 224 | 227.9 | 86.140% / 97.968% | `mambavision_large_21k.pdparams` |
+| `MambaVision_L2` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_L2.yaml) | 224 | 241.5 | 85.282% / 97.160% | `mambavision_large2_1k.pdparams` |
+| `MambaVision_L2_512_21K` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_L2_512_21K.yaml) | 512 | 241.5 | 87.114% / 98.256% | `mambavision_L2_21k_240m_512.pdparams` |
+| `MambaVision_L3_256_21K` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_L3_256_21K.yaml) | 256 | 739.6 | 87.294% / 98.318% | `mambavision_L3_21k_740m_256.pdparams` |
+| `MambaVision_L3_512_21K` | [配置](../../../../ppcls/configs/ImageNet/MambaVision/MambaVision_L3_512_21K.yaml) | 512 | 739.6 | 87.822% / 98.452% | `mambavision_L3_21k_740m_512.pdparams` |
+
+以上 Paddle 指标使用转换后的 PaddlePaddle 权重在 ImageNet-1K 50,000 张验证图像上评估。转换前后的逐图 Top-1 预测一致率均为 100%，logits 最大绝对差均小于 `1e-4`。这些结果用于验证权重转换和前向计算的一致性，不代表使用 PaddlePaddle 从头训练复现论文精度。
+
+全部权重可从 [AI Studio MambaVision 模型空间](https://aistudio.baidu.com/modelsdetail/51615) 下载。请根据表中的 PaddleClas 名称选择对应的权重文件。
+
+当前不提供 `pretrained=True` 自动下载。下载权重后，请将本地 `.pdparams` 文件路径传给模型工厂的 `pretrained` 参数，或通过配置项 `Global.pretrained_model` 加载。
+
+## 3. 使用方法
+
+以下命令以 `MambaVision_T` 为例。使用其他规格时，需要同时替换配置文件和权重文件。
+
+### 3.1 训练
+
+```bash
+python tools/train.py \
+  -c ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml \
+  -o Global.device=gpu
+```
+
+### 3.2 评估
+
+```bash
+python tools/eval.py \
+  -c ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml \
+  -o Global.pretrained_model=/path/to/mambavision_tiny_1k.pdparams \
+  -o Global.device=gpu
+```
+
+### 3.3 推理
+
+```bash
+python tools/infer.py \
+  -c ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml \
+  -o Global.pretrained_model=/path/to/mambavision_tiny_1k.pdparams \
+  -o Infer.infer_imgs=/path/to/image.jpg \
+  -o Global.device=gpu
+```
+
+### 3.4 Python API
+
+```python
+import paddle
+
+from ppcls.arch.backbone import MambaVision_T
+
+model = MambaVision_T(pretrained="/path/to/mambavision_tiny_1k.pdparams")
+model.eval()
+
+x = paddle.randn([1, 3, 224, 224])
+with paddle.no_grad():
+    logits = model(x)
+print(logits.shape)  # [1, 1000]
+```
+
+## 4. 许可证
+
+MambaVision 源代码遵循 [NVIDIA Source Code License-NC](https://github.com/NVlabs/MambaVision/blob/main/LICENSE)，预训练权重遵循 [CC-BY-NC-SA-4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)。使用代码和权重前请确认符合相应许可证条款。

--- a/docs/zh_CN/models/ImageNet1k/README.md
+++ b/docs/zh_CN/models/ImageNet1k/README.md
@@ -837,6 +837,28 @@ DeiT（Data-efficient Image Transformers）系列模型的精度、速度指标�
 | DSNet_small | 0.8196    | 0.9596    | -                | -                | -                 | 3.5      | 23.0      | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DSNet_small_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/DSNet_small_infer.tar) |
 | DSNet_base  | 0.8175    | 0.9522    | -                | -                | -                 | 8.4      | 49.3      | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/DSNet_base_pretrained.pdparams) | [下载链接](https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/inference/DSNet_base_infer.tar) |
 
+<a name="MambaVision"></a>
+
+## MambaVision 系列
+
+MambaVision 提供 11 个模型规格，模型介绍、配置和使用方法请参考：[MambaVision 系列模型文档](MambaVision.md)。预训练权重可从 [AI Studio MambaVision 模型空间](https://aistudio.baidu.com/modelsdetail/51615) 下载。
+
+| 模型 | Top-1 Acc | Top-5 Acc | 分辨率 | Params(M) | 预训练模型 |
+| --- | ---: | ---: | ---: | ---: | --- |
+| MambaVision_T | 0.82176 | 0.96172 | 224 | 31.8 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_T2 | 0.82636 | 0.96272 | 224 | 35.1 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_S | 0.83232 | 0.96502 | 224 | 50.1 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_B | 0.84204 | 0.96848 | 224 | 97.7 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_B_21K | 0.84876 | 0.97478 | 224 | 97.7 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_L | 0.84954 | 0.97078 | 224 | 227.9 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_L_21K | 0.86140 | 0.97968 | 224 | 227.9 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_L2 | 0.85282 | 0.97160 | 224 | 241.5 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_L2_512_21K | 0.87114 | 0.98256 | 512 | 241.5 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_L3_256_21K | 0.87294 | 0.98318 | 256 | 739.6 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+| MambaVision_L3_512_21K | 0.87822 | 0.98452 | 512 | 739.6 | [下载链接](https://aistudio.baidu.com/modelsdetail/51615) |
+
+> 以上指标使用转换后的 PaddlePaddle 权重在 ImageNet-1K 验证集上评估，用于验证转换前后的前向一致性，不代表使用 PaddlePaddle 从头训练复现论文精度。
+
 <a name="Transformer_lite"></a>
 
 ### 4.2 轻量级模型

--- a/ppcls/arch/backbone/__init__.py
+++ b/ppcls/arch/backbone/__init__.py
@@ -335,6 +335,12 @@ from .model_zoo.fastvit import FastViT_T8, FastViT_T12, FastViT_SA12, FastViT_SA
 from .model_zoo.edgenext import EdgeNeXt_XX_Small, EdgeNeXt_X_Small, EdgeNeXt_Small, EdgeNeXt_Base
 from .model_zoo.swiftformer import SwiftFormer_XS, SwiftFormer_S, SwiftFormer_L1, SwiftFormer_L3
 
+from .model_zoo.mambavision import (
+    MambaVision_T, MambaVision_T2, MambaVision_S, MambaVision_B,
+    MambaVision_B_21K, MambaVision_L, MambaVision_L_21K, MambaVision_L2,
+    MambaVision_L2_512_21K, MambaVision_L3_256_21K,
+    MambaVision_L3_512_21K)
+
 
 # help whl get all the models' api (class type) and components' api (func type)
 def get_apis():

--- a/ppcls/arch/backbone/model_zoo/mambavision.py
+++ b/ppcls/arch/backbone/model_zoo/mambavision.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2025, NVIDIA Corporation. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NVIDIA-Source-Code-License-NC
+# PaddlePaddle port of NVLabs MambaVision.
+
+from .mambavision_impl.mamba_vision import build_mambavision
+
+MODEL_DOWNLOAD_URL = "https://aistudio.baidu.com/modelsdetail/51615"
+
+_VARIANTS = {
+    "MambaVision_T": "mamba_vision_T",
+    "MambaVision_T2": "mamba_vision_T2",
+    "MambaVision_S": "mamba_vision_S",
+    "MambaVision_B": "mamba_vision_B",
+    "MambaVision_B_21K": "mamba_vision_B_21k",
+    "MambaVision_L": "mamba_vision_L",
+    "MambaVision_L_21K": "mamba_vision_L_21k",
+    "MambaVision_L2": "mamba_vision_L2",
+    "MambaVision_L2_512_21K": "mamba_vision_L2_512_21k",
+    "MambaVision_L3_256_21K": "mamba_vision_L3_256_21k",
+    "MambaVision_L3_512_21K": "mamba_vision_L3_512_21k",
+}
+
+__all__ = list(_VARIANTS)
+
+
+def _build(variant, pretrained=False, use_ssld=False, **kwargs):
+    del use_ssld
+    class_num = kwargs.pop("class_num", 1000)
+    if pretrained is True:
+        raise ValueError(
+            "Automatic pretrained weight download is not available. "
+            f"Download the PaddlePaddle checkpoint from {MODEL_DOWNLOAD_URL} "
+            "and pass its local .pdparams path through pretrained."
+        )
+    checkpoint = pretrained if isinstance(pretrained, str) else None
+    return build_mambavision(
+        _VARIANTS[variant],
+        pretrained=checkpoint,
+        num_classes=class_num,
+        **kwargs,
+    )
+
+
+def MambaVision_T(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_T", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_T2(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_T2", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_S(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_S", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_B(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_B", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_B_21K(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_B_21K", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_L(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_L", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_L_21K(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_L_21K", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_L2(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_L2", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_L2_512_21K(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_L2_512_21K", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_L3_256_21K(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_L3_256_21K", pretrained, use_ssld, **kwargs)
+
+
+def MambaVision_L3_512_21K(pretrained=False, use_ssld=False, **kwargs):
+    return _build("MambaVision_L3_512_21K", pretrained, use_ssld, **kwargs)

--- a/ppcls/arch/backbone/model_zoo/mambavision_impl/__init__.py
+++ b/ppcls/arch/backbone/model_zoo/mambavision_impl/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025, NVIDIA Corporation. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NVIDIA-Source-Code-License-NC
+
+from .mamba_block import *
+from .mamba_vision import *

--- a/ppcls/arch/backbone/model_zoo/mambavision_impl/mamba_block.py
+++ b/ppcls/arch/backbone/model_zoo/mambavision_impl/mamba_block.py
@@ -1,0 +1,650 @@
+# Copyright (c) 2025, NVIDIA Corporation. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NVIDIA-Source-Code-License-NC
+# PaddlePaddle port of NVLabs MambaVision.
+
+import math
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+
+
+def drop_path(x, drop_prob=0.0, training=False):
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1.0 - drop_prob
+    shape = [x.shape[0]] + [1] * (len(x.shape) - 1)
+    random_tensor = keep_prob + paddle.rand(shape, dtype=x.dtype)
+    random_tensor = paddle.floor(random_tensor)
+    return (x / keep_prob) * random_tensor
+
+
+class DropPath(nn.Layer):
+
+    def __init__(self, drop_prob=0.0):
+        super().__init__()
+        self.drop_prob = float(drop_prob)
+
+    def forward(self, x):
+        return drop_path(x, self.drop_prob, self.training)
+
+
+class LayerNorm2D(nn.Layer):
+
+    def __init__(self, num_channels, epsilon=1e-5):
+        super().__init__()
+        self.num_channels = num_channels
+        self.epsilon = epsilon
+        self.weight = self.create_parameter(
+            shape=[num_channels],
+            default_initializer=nn.initializer.Constant(1.0),
+        )
+        self.bias = self.create_parameter(
+            shape=[num_channels],
+            default_initializer=nn.initializer.Constant(0.0),
+        )
+
+    def forward(self, x):
+        mean = paddle.mean(x, axis=1, keepdim=True)
+        var = paddle.mean((x - mean) * (x - mean), axis=1, keepdim=True)
+        x = (x - mean) * paddle.rsqrt(var + self.epsilon)
+        weight = self.weight.reshape([1, -1, 1, 1])
+        bias = self.bias.reshape([1, -1, 1, 1])
+        return x * weight + bias
+
+
+class ChannelFirstLayerNorm(nn.Layer):
+
+    def __init__(self, num_channels, epsilon=1e-5):
+        super().__init__()
+        self.norm = nn.LayerNorm(num_channels, epsilon=epsilon)
+
+    def forward(self, x):
+        x = x.transpose([0, 2, 3, 1])
+        x = self.norm(x)
+        return x.transpose([0, 3, 1, 2])
+
+
+class TorchCompatibleLayerNorm(nn.LayerNorm):
+    """Use PyTorch's CUDA LayerNorm reduction order for strict eval audits."""
+
+    def __init__(self,
+                 normalized_shape,
+                 epsilon=1e-5,
+                 implementation="paddle"):
+        super().__init__(normalized_shape, epsilon=epsilon)
+        if implementation != "paddle":
+            raise ValueError(
+                f"Unsupported LayerNorm implementation: {implementation!r}")
+        self.implementation = implementation
+        self.torch_epsilon = float(epsilon)
+
+    def forward(self, x):
+        # Explicit dispatch is required by Paddle dy2static; zero-argument super()
+        # cannot be transformed in this overridden LayerNorm path.
+        return nn.LayerNorm.forward(self, x)
+
+
+class Mlp(nn.Layer):
+
+    def __init__(
+        self,
+        in_features,
+        hidden_features=None,
+        out_features=None,
+        act_layer=nn.GELU,
+        drop=0.0,
+    ):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = act_layer()
+        self.drop1 = nn.Dropout(drop)
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop2 = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop1(x)
+        x = self.fc2(x)
+        x = self.drop2(x)
+        return x
+
+
+def window_partition(x, window_size):
+    b, c, h, w = x.shape
+    x = x.reshape(
+        [b, c, h // window_size, window_size, w // window_size, window_size])
+    windows = x.transpose([0, 2, 4, 3, 5,
+                           1]).reshape([-1, window_size * window_size, c])
+    return windows
+
+
+def window_reverse(windows, window_size, height, width):
+    b = int(windows.shape[0] / (height * width / window_size / window_size))
+    x = windows.reshape([
+        b,
+        height // window_size,
+        width // window_size,
+        window_size,
+        window_size,
+        -1,
+    ])
+    x = x.transpose([0, 5, 1, 3, 2,
+                     4]).reshape([b, windows.shape[2], height, width])
+    return x
+
+
+class Downsample(nn.Layer):
+
+    def __init__(self, dim, keep_dim=False):
+        super().__init__()
+        dim_out = dim if keep_dim else 2 * dim
+        self.reduction = nn.Sequential(
+            nn.Conv2D(dim, dim_out, 3, stride=2, padding=1, bias_attr=False), )
+
+    def forward(self, x):
+        return self.reduction(x)
+
+
+class PatchEmbed(nn.Layer):
+
+    def __init__(self, in_chans=3, in_dim=64, dim=96):
+        super().__init__()
+        self.proj = nn.Identity()
+        self.conv_down = nn.Sequential(
+            nn.Conv2D(in_chans,
+                      in_dim,
+                      3,
+                      stride=2,
+                      padding=1,
+                      bias_attr=False),
+            nn.BatchNorm2D(in_dim, epsilon=1e-4),
+            nn.ReLU(),
+            nn.Conv2D(in_dim, dim, 3, stride=2, padding=1, bias_attr=False),
+            nn.BatchNorm2D(dim, epsilon=1e-4),
+            nn.ReLU(),
+        )
+
+    def forward(self, x):
+        x = self.proj(x)
+        x = self.conv_down(x)
+        return x
+
+
+class ConvBlock(nn.Layer):
+
+    def __init__(
+        self,
+        dim,
+        drop_path=0.0,
+        layer_scale=None,
+        kernel_size=3,
+        gelu_impl="paddle",
+    ):
+        super().__init__()
+        if gelu_impl != "paddle":
+            raise ValueError(f"Unsupported GELU implementation: {gelu_impl!r}")
+        self.gelu_impl = gelu_impl
+        self.conv1 = nn.Conv2D(dim,
+                               dim,
+                               kernel_size=kernel_size,
+                               stride=1,
+                               padding=1)
+        self.norm1 = nn.BatchNorm2D(dim, epsilon=1e-5)
+        self.conv2 = nn.Conv2D(dim,
+                               dim,
+                               kernel_size=kernel_size,
+                               stride=1,
+                               padding=1)
+        self.norm2 = nn.BatchNorm2D(dim, epsilon=1e-5)
+        use_layer_scale = layer_scale is not None and isinstance(
+            layer_scale, (int, float))
+        self.layer_scale = use_layer_scale
+        if use_layer_scale:
+            self.gamma = self.create_parameter(
+                shape=[dim],
+                default_initializer=nn.initializer.Constant(
+                    float(layer_scale)),
+            )
+        self.drop_path = DropPath(
+            drop_path) if drop_path > 0.0 else nn.Identity()
+
+    def forward(self, x):
+        residual = x
+        x = self.conv1(x)
+        x = self.norm1(x)
+        x = F.gelu(x, approximate=True)
+        x = self.conv2(x)
+        x = self.norm2(x)
+        if self.layer_scale:
+            x = x * self.gamma.reshape([1, -1, 1, 1])
+        x = residual + self.drop_path(x)
+        return x
+
+
+def selective_scan_paddle(
+    u,
+    delta,
+    A,
+    B,
+    C,
+    D=None,
+    z=None,
+    delta_bias=None,
+    delta_softplus=False,
+    return_last_state=False,
+    implementation="sequential",
+):
+    if implementation not in {"sequential", "parallel"}:
+        raise ValueError(
+            f"Unsupported selective scan implementation: {implementation!r}")
+    dtype_in = u.dtype
+    u = u.astype("float32")
+    delta = delta.astype("float32")
+    if delta_bias is not None:
+        delta = delta + delta_bias.astype("float32").reshape([1, -1, 1])
+    if delta_softplus:
+        delta = F.softplus(delta)
+
+    batch = u.shape[0]
+    dim = A.shape[0]
+    dstate = A.shape[1]
+    B = B.astype("float32")
+    C = C.astype("float32")
+
+    deltaA = paddle.exp(paddle.einsum("bdl,dn->bdln", delta, A))
+    deltaB_u = paddle.einsum("bdl,bnl,bdl->bdln", delta, B, u)
+    if implementation == "sequential":
+        x = paddle.zeros([batch, dim, dstate], dtype=A.dtype)
+        ys = []
+        last_state = None
+        for i in range(u.shape[2]):
+            x = deltaA[:, :, i, :] * x + deltaB_u[:, :, i, :]
+            y = paddle.einsum("bdn,bn->bd", x, C[:, :, i])
+            if i == u.shape[2] - 1:
+                last_state = x
+            ys.append(y)
+        y = paddle.stack(ys, axis=2)
+    else:
+        # Affine recurrences compose associatively:
+        # (a2, b2) o (a1, b1) = (a2 * a1, b2 + a2 * b1).
+        # A Hillis-Steele scan reduces L sequential GPU launch groups to log2(L)
+        # vectorized groups. It changes floating-point reduction order, so it is
+        # an opt-in performance backend rather than the strict-alignment default.
+        scan_a = deltaA
+        scan_b = deltaB_u
+        offset = 1
+        sequence_length = u.shape[2]
+        while offset < sequence_length:
+            prev_a = scan_a[:, :, :-offset, :]
+            prev_b = scan_b[:, :, :-offset, :]
+            tail_a = scan_a[:, :, offset:, :]
+            tail_b = scan_b[:, :, offset:, :]
+            scan_a = paddle.concat([scan_a[:, :, :offset, :], tail_a * prev_a],
+                                   axis=2)
+            scan_b = paddle.concat(
+                [scan_b[:, :, :offset, :], tail_b + tail_a * prev_b], axis=2)
+            offset *= 2
+        last_state = scan_b[:, :, -1, :]
+        y = paddle.einsum("bdln,bnl->bdl", scan_b, C)
+    out = y if D is None else y + u * D.reshape([1, -1, 1])
+    if z is not None:
+        out = out * F.silu(z)
+    out = out.astype(dtype_in)
+    return out if not return_last_state else (out, last_state)
+
+
+class MambaVisionMixer(nn.Layer):
+
+    def __init__(
+        self,
+        d_model,
+        d_state=16,
+        d_conv=4,
+        expand=2,
+        dt_rank="auto",
+        dt_min=0.001,
+        dt_max=0.1,
+        dt_init="random",
+        dt_scale=1.0,
+        dt_init_floor=1e-4,
+        conv_bias=True,
+        bias=False,
+        use_fast_path=True,
+        layer_idx=None,
+        scan_impl="sequential",
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.d_state = d_state
+        self.d_conv = d_conv
+        self.expand = expand
+        self.d_inner = int(self.expand * self.d_model)
+        self.dt_rank = math.ceil(self.d_model /
+                                 16) if dt_rank == "auto" else dt_rank
+        self.use_fast_path = use_fast_path
+        self.layer_idx = layer_idx
+        self.scan_impl = scan_impl
+
+        self.in_proj = nn.Linear(self.d_model, self.d_inner, bias_attr=bias)
+        self.x_proj = nn.Linear(
+            self.d_inner // 2,
+            self.dt_rank + self.d_state * 2,
+            bias_attr=False,
+        )
+        self.dt_proj = nn.Linear(self.dt_rank,
+                                 self.d_inner // 2,
+                                 bias_attr=True)
+
+        dt_init_std = self.dt_rank**-0.5 * dt_scale
+        if dt_init == "constant":
+            self.dt_proj.weight.set_value(
+                paddle.full(self.dt_proj.weight.shape,
+                            dt_init_std,
+                            dtype=self.dt_proj.weight.dtype))
+        elif dt_init == "random":
+            self.dt_proj.weight.set_value(
+                paddle.uniform(
+                    self.dt_proj.weight.shape,
+                    min=-dt_init_std,
+                    max=dt_init_std,
+                    dtype=self.dt_proj.weight.dtype,
+                ))
+        else:
+            raise NotImplementedError(dt_init)
+
+        dt = paddle.exp(
+            paddle.rand([self.d_inner // 2], dtype="float32") *
+            (math.log(dt_max) - math.log(dt_min)) + math.log(dt_min))
+        dt = paddle.clip(dt, min=dt_init_floor)
+        inv_dt = dt + paddle.log(-paddle.expm1(-dt))
+        self.dt_proj.bias.set_value(inv_dt)
+
+        A = paddle.arange(1, self.d_state + 1, dtype="float32")
+        A = paddle.tile(A.reshape([1, -1]), [self.d_inner // 2, 1])
+        self.A_log = self.create_parameter(
+            shape=A.shape,
+            default_initializer=nn.initializer.Assign(paddle.log(A)),
+        )
+        self.D = self.create_parameter(
+            shape=[self.d_inner // 2],
+            default_initializer=nn.initializer.Constant(1.0),
+        )
+        self.out_proj = nn.Linear(self.d_inner, self.d_model, bias_attr=bias)
+
+        conv_bias_attr = False if conv_bias // 2 == 0 else True
+        self.conv1d_x = nn.Conv1D(
+            self.d_inner // 2,
+            self.d_inner // 2,
+            kernel_size=d_conv,
+            padding=d_conv // 2,
+            groups=self.d_inner // 2,
+            bias_attr=conv_bias_attr,
+        )
+        self.conv1d_z = nn.Conv1D(
+            self.d_inner // 2,
+            self.d_inner // 2,
+            kernel_size=d_conv,
+            padding=d_conv // 2,
+            groups=self.d_inner // 2,
+            bias_attr=conv_bias_attr,
+        )
+
+    def forward(self, hidden_states):
+        _, seqlen, _ = hidden_states.shape
+        xz = self.in_proj(hidden_states)
+        xz = xz.transpose([0, 2, 1])
+        x, z = paddle.chunk(xz, 2, axis=1)
+        A = -paddle.exp(self.A_log.astype("float32"))
+
+        x = F.silu(self.conv1d_x(x))
+        z = F.silu(self.conv1d_z(z))
+        x_dbl = self.x_proj(
+            x.transpose([0, 2, 1]).reshape([-1, self.d_inner // 2]))
+        dt, B, C = paddle.split(x_dbl,
+                                [self.dt_rank, self.d_state, self.d_state],
+                                axis=-1)
+        dt = self.dt_proj(dt).reshape([-1, seqlen,
+                                       self.d_inner // 2]).transpose([0, 2, 1])
+        B = B.reshape([-1, seqlen, self.d_state]).transpose([0, 2, 1])
+        C = C.reshape([-1, seqlen, self.d_state]).transpose([0, 2, 1])
+        y = selective_scan_paddle(
+            x,
+            dt,
+            A,
+            B,
+            C,
+            self.D.astype("float32"),
+            z=None,
+            delta_bias=self.dt_proj.bias.astype("float32"),
+            delta_softplus=True,
+            return_last_state=False,
+            implementation=self.scan_impl,
+        )
+        y = paddle.concat([y, z], axis=1)
+        y = y.transpose([0, 2, 1])
+        out = self.out_proj(y)
+        return out
+
+
+class Attention(nn.Layer):
+
+    def __init__(
+        self,
+        dim,
+        num_heads=8,
+        qkv_bias=False,
+        qk_norm=False,
+        attn_drop=0.0,
+        proj_drop=0.0,
+        norm_layer=nn.LayerNorm,
+    ):
+        super().__init__()
+        assert dim % num_heads == 0
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv = nn.Linear(dim, dim * 3, bias_attr=qkv_bias)
+        self.q_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.k_norm = norm_layer(self.head_dim) if qk_norm else nn.Identity()
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x):
+        b, n, c = x.shape
+        qkv = self.qkv(x).reshape([b, n, 3, self.num_heads, self.head_dim])
+        qkv = qkv.transpose([2, 0, 3, 1, 4])
+        q, k, v = paddle.unstack(qkv, axis=0)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+
+        q = q * self.scale
+        attn = paddle.matmul(q, k, transpose_y=True)
+        attn = F.softmax(attn, axis=-1)
+        attn = self.attn_drop(attn)
+        x = paddle.matmul(attn, v)
+        x = x.transpose([0, 2, 1, 3]).reshape([b, n, c])
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+
+class Block(nn.Layer):
+
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        counter,
+        transformer_blocks,
+        mlp_ratio=4.0,
+        qkv_bias=False,
+        qk_scale=False,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+        act_layer=nn.GELU,
+        norm_layer=nn.LayerNorm,
+        Mlp_block=Mlp,
+        layer_scale=None,
+        scan_impl="sequential",
+    ):
+        super().__init__()
+        norm_impl = "paddle"
+        block_norm = (TorchCompatibleLayerNorm(dim, implementation=norm_impl)
+                      if norm_layer is nn.LayerNorm else norm_layer(dim))
+        self.norm1 = block_norm
+        if counter in transformer_blocks:
+            self.mixer = Attention(
+                dim,
+                num_heads=num_heads,
+                qkv_bias=qkv_bias,
+                qk_norm=qk_scale,
+                attn_drop=attn_drop,
+                proj_drop=drop,
+                norm_layer=norm_layer,
+            )
+        else:
+            self.mixer = MambaVisionMixer(
+                d_model=dim,
+                d_state=8,
+                d_conv=3,
+                expand=1,
+                scan_impl=scan_impl,
+            )
+
+        self.drop_path = DropPath(
+            drop_path) if drop_path > 0.0 else nn.Identity()
+        self.norm2 = (TorchCompatibleLayerNorm(dim, implementation=norm_impl)
+                      if norm_layer is nn.LayerNorm else norm_layer(dim))
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp_block(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=drop,
+        )
+        use_layer_scale = layer_scale is not None and isinstance(
+            layer_scale, (int, float))
+        if use_layer_scale:
+            self.gamma_1 = self.create_parameter(
+                shape=[dim],
+                default_initializer=nn.initializer.Constant(
+                    float(layer_scale)),
+            )
+            self.gamma_2 = self.create_parameter(
+                shape=[dim],
+                default_initializer=nn.initializer.Constant(
+                    float(layer_scale)),
+            )
+        else:
+            self.gamma_1 = None
+            self.gamma_2 = None
+
+    def forward(self, x):
+        gamma_1 = self.gamma_1 if self.gamma_1 is not None else 1.0
+        gamma_2 = self.gamma_2 if self.gamma_2 is not None else 1.0
+        x = x + self.drop_path(gamma_1 * self.mixer(self.norm1(x)))
+        x = x + self.drop_path(gamma_2 * self.mlp(self.norm2(x)))
+        return x
+
+
+class MambaVisionLayer(nn.Layer):
+
+    def __init__(
+        self,
+        dim,
+        depth,
+        num_heads,
+        window_size,
+        conv=False,
+        downsample=True,
+        mlp_ratio=4.0,
+        qkv_bias=True,
+        qk_scale=None,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+        layer_scale=None,
+        layer_scale_conv=None,
+        transformer_blocks=None,
+        scan_impl="sequential",
+    ):
+        super().__init__()
+        transformer_blocks = transformer_blocks or []
+        self.conv = conv
+        conv_gelu_impl = "paddle"
+        if conv:
+            self.blocks = nn.LayerList([
+                ConvBlock(
+                    dim=dim,
+                    drop_path=drop_path[i]
+                    if isinstance(drop_path, list) else drop_path,
+                    layer_scale=layer_scale_conv,
+                    gelu_impl=conv_gelu_impl,
+                ) for i in range(depth)
+            ])
+            self.transformer_block = False
+        else:
+            self.blocks = nn.LayerList([
+                Block(
+                    dim=dim,
+                    counter=i,
+                    transformer_blocks=transformer_blocks,
+                    num_heads=num_heads,
+                    mlp_ratio=mlp_ratio,
+                    qkv_bias=qkv_bias,
+                    qk_scale=qk_scale,
+                    drop=drop,
+                    attn_drop=attn_drop,
+                    drop_path=drop_path[i]
+                    if isinstance(drop_path, list) else drop_path,
+                    layer_scale=layer_scale,
+                    scan_impl=scan_impl,
+                ) for i in range(depth)
+            ])
+            self.transformer_block = True
+
+        self.downsample = None if not downsample else Downsample(dim=dim)
+        self.window_size = window_size
+
+    def forward(self, x, return_stage_output=False):
+        _, _, h, w = x.shape
+        pad_r = 0
+        pad_b = 0
+        hp = h
+        wp = w
+
+        if self.transformer_block:
+            pad_r = (self.window_size -
+                     w % self.window_size) % self.window_size
+            pad_b = (self.window_size -
+                     h % self.window_size) % self.window_size
+            if pad_r > 0 or pad_b > 0:
+                x = F.pad(
+                    x,
+                    pad=[0, pad_r, 0, pad_b],
+                    mode="constant",
+                    value=0.0,
+                    data_format="NCHW",
+                )
+                _, _, hp, wp = x.shape
+            x = window_partition(x, self.window_size)
+
+        for blk in self.blocks:
+            x = blk(x)
+
+        if self.transformer_block:
+            x = window_reverse(x, self.window_size, hp, wp)
+            if pad_r > 0 or pad_b > 0:
+                x = x[:, :, :h, :w]
+
+        stage_output = x
+        x = x if self.downsample is None else self.downsample(x)
+        if return_stage_output:
+            return x, stage_output
+        return x

--- a/ppcls/arch/backbone/model_zoo/mambavision_impl/mamba_vision.py
+++ b/ppcls/arch/backbone/model_zoo/mambavision_impl/mamba_vision.py
@@ -1,0 +1,432 @@
+# Copyright (c) 2025, NVIDIA Corporation. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NVIDIA-Source-Code-License-NC
+# PaddlePaddle port of NVLabs MambaVision.
+
+import sys
+from pathlib import Path
+
+import paddle.nn as nn
+
+import paddle
+
+from .mamba_block import ChannelFirstLayerNorm, LayerNorm2D, MambaVisionLayer, PatchEmbed
+
+MODEL_CONFIGS = {
+    "mamba_vision_T":
+    dict(
+        depths=[1, 3, 8, 4],
+        num_heads=[2, 4, 8, 16],
+        window_size=[8, 8, 14, 7],
+        dim=80,
+        in_dim=32,
+        mlp_ratio=4,
+        drop_path_rate=0.2,
+        layer_scale=None,
+    ),
+    "mamba_vision_T2":
+    dict(
+        depths=[1, 3, 11, 4],
+        num_heads=[2, 4, 8, 16],
+        window_size=[8, 8, 14, 7],
+        dim=80,
+        in_dim=32,
+        mlp_ratio=4,
+        drop_path_rate=0.2,
+        layer_scale=None,
+    ),
+    "mamba_vision_S":
+    dict(
+        depths=[3, 3, 7, 5],
+        num_heads=[2, 4, 8, 16],
+        window_size=[8, 8, 14, 7],
+        dim=96,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.2,
+        layer_scale=None,
+    ),
+    "mamba_vision_B":
+    dict(
+        depths=[3, 3, 10, 5],
+        num_heads=[2, 4, 8, 16],
+        window_size=[8, 8, 14, 7],
+        dim=128,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.3,
+        layer_scale=1e-5,
+    ),
+    "mamba_vision_B_21k":
+    dict(
+        depths=[3, 3, 10, 5],
+        num_heads=[2, 4, 8, 16],
+        window_size=[8, 8, 14, 7],
+        dim=128,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.3,
+        layer_scale=1e-5,
+    ),
+    "mamba_vision_L":
+    dict(
+        depths=[3, 3, 10, 5],
+        num_heads=[4, 8, 16, 32],
+        window_size=[8, 8, 14, 7],
+        dim=196,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.3,
+        layer_scale=1e-5,
+    ),
+    "mamba_vision_L_21k":
+    dict(
+        depths=[3, 3, 10, 5],
+        num_heads=[4, 8, 16, 32],
+        window_size=[8, 8, 14, 7],
+        dim=196,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.3,
+        layer_scale=1e-5,
+    ),
+    "mamba_vision_L2":
+    dict(
+        depths=[3, 3, 12, 5],
+        num_heads=[4, 8, 16, 32],
+        window_size=[8, 8, 14, 7],
+        dim=196,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.3,
+        layer_scale=1e-5,
+    ),
+    "mamba_vision_L2_512_21k":
+    dict(
+        depths=[3, 3, 12, 5],
+        num_heads=[4, 8, 16, 32],
+        window_size=[8, 8, 32, 16],
+        dim=196,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.3,
+        layer_scale=1e-5,
+    ),
+    "mamba_vision_L3_256_21k":
+    dict(
+        depths=[3, 3, 20, 10],
+        num_heads=[4, 8, 16, 32],
+        window_size=[8, 8, 16, 8],
+        dim=256,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.5,
+        layer_scale=1e-5,
+    ),
+    "mamba_vision_L3_512_21k":
+    dict(
+        depths=[3, 3, 20, 10],
+        num_heads=[4, 8, 16, 32],
+        window_size=[8, 8, 32, 16],
+        dim=256,
+        in_dim=64,
+        mlp_ratio=4,
+        drop_path_rate=0.5,
+        layer_scale=1e-5,
+    ),
+}
+
+
+def _register_with_paddleclas(cls):
+    # Native PaddleClas registration is provided by ppcls.arch.backbone.__init__.
+    return cls
+
+
+class MambaVision(nn.Layer):
+
+    def __init__(
+        self,
+        dim,
+        in_dim,
+        depths,
+        window_size,
+        mlp_ratio,
+        num_heads,
+        drop_path_rate=0.2,
+        in_chans=3,
+        num_classes=1000,
+        qkv_bias=True,
+        qk_scale=None,
+        drop_rate=0.0,
+        attn_drop_rate=0.0,
+        layer_scale=None,
+        layer_scale_conv=None,
+        scan_impl="sequential",
+        **kwargs,
+    ):
+        super().__init__()
+        num_features = int(dim * 2**(len(depths) - 1))
+        self.num_classes = num_classes
+        self.num_features = num_features
+        self.dims = [int(dim * 2**i) for i in range(len(depths))]
+        self.patch_embed = PatchEmbed(in_chans=in_chans,
+                                      in_dim=in_dim,
+                                      dim=dim)
+        dpr = paddle.linspace(0, drop_path_rate, sum(depths)).numpy().tolist()
+        self.levels = nn.LayerList()
+        for i in range(len(depths)):
+            conv = i == 0 or i == 1
+            if depths[i] % 2 != 0:
+                transformer_blocks = list(range(depths[i] // 2 + 1, depths[i]))
+            else:
+                transformer_blocks = list(range(depths[i] // 2, depths[i]))
+            level = MambaVisionLayer(
+                dim=int(dim * 2**i),
+                depth=depths[i],
+                num_heads=num_heads[i],
+                window_size=window_size[i],
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                qk_scale=qk_scale,
+                conv=conv,
+                drop=drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[sum(depths[:i]):sum(depths[:i + 1])],
+                downsample=(i < 3),
+                layer_scale=layer_scale,
+                layer_scale_conv=layer_scale_conv,
+                transformer_blocks=transformer_blocks,
+                scan_impl=scan_impl,
+            )
+            self.levels.append(level)
+        self.norm = nn.BatchNorm2D(num_features)
+        self.avgpool = nn.AdaptiveAvgPool2D(1)
+        self.head = nn.Linear(
+            num_features, num_classes) if num_classes > 0 else nn.Identity()
+
+    def forward_features(self, x):
+        x = self.patch_embed(x)
+        for level in self.levels:
+            x = level(x)
+        x = self.norm(x)
+        x = self.avgpool(x)
+        x = paddle.flatten(x, 1)
+        return x
+
+    def forward_intermediates(self,
+                              x,
+                              out_indices=(0, 1, 2, 3),
+                              norm_layer=None):
+        x = self.patch_embed(x)
+        outs = []
+        for i, level in enumerate(self.levels):
+            x, stage = level(x, return_stage_output=True)
+            if i in out_indices:
+                if norm_layer is not None:
+                    stage = norm_layer[i](stage)
+                outs.append(stage)
+        return outs if len(out_indices) else x
+
+    def forward(self, x):
+        x = self.forward_features(x)
+        x = self.head(x)
+        return x
+
+
+@_register_with_paddleclas
+class MambaVisionBackbone(MambaVision):
+
+    def __init__(
+            self,
+            dim,
+            in_dim,
+            depths,
+            window_size,
+            mlp_ratio,
+            num_heads,
+            out_indices=(0, 1, 2, 3),
+            norm_layer="ln2d",
+            **kwargs,
+    ):
+        super().__init__(
+            dim=dim,
+            in_dim=in_dim,
+            depths=depths,
+            window_size=window_size,
+            mlp_ratio=mlp_ratio,
+            num_heads=num_heads,
+            **kwargs,
+        )
+        self.out_indices = out_indices
+        norm_layer = norm_layer.lower()
+        norm_cls = {
+            "ln2d": LayerNorm2D,
+            "bn": nn.BatchNorm2D,
+            "ln": ChannelFirstLayerNorm,
+        }.get(norm_layer)
+        if norm_cls is None and norm_layer != "ln":
+            raise ValueError(f"Unsupported norm_layer: {norm_layer}")
+        self.outnorms = nn.LayerList()
+        for i, channels in enumerate(self.dims):
+            if i in out_indices:
+                self.outnorms.append(norm_cls(channels))
+            else:
+                self.outnorms.append(nn.Identity())
+        del self.norm
+        del self.head
+
+    def forward(self, x):
+        x = self.patch_embed(x)
+        outs = []
+        for i, level in enumerate(self.levels):
+            x, stage = level(x, return_stage_output=True)
+            if i in self.out_indices:
+                out = self.outnorms[i](stage)
+                outs.append(out)
+        return outs if len(self.out_indices) else x
+
+
+@_register_with_paddleclas
+class MambaVisionClassifier(nn.Layer):
+    """PaddleClas Arch-compatible classification wrapper."""
+
+    def __init__(
+        self,
+        model_name="mamba_vision_T",
+        pretrained=None,
+        class_num=1000,
+        **kwargs,
+    ):
+        super().__init__()
+        kwargs.setdefault("num_classes", class_num)
+        self.model = build_mambavision(model_name=model_name,
+                                       pretrained=pretrained,
+                                       **kwargs)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+def build_mambavision(model_name="mamba_vision_T", pretrained=None, **kwargs):
+    if model_name not in MODEL_CONFIGS:
+        raise ValueError(f"Unknown MambaVision variant: {model_name}")
+    cfg = MODEL_CONFIGS[model_name].copy()
+    cfg.update(kwargs)
+    model = MambaVision(**cfg)
+    if pretrained:
+        state = paddle.load(pretrained)
+        model.set_state_dict(state)
+    return model
+
+
+def load_matching_mambavision_checkpoint(model, checkpoint_path):
+    """Load only tensors whose names and shapes match a MambaVision model.
+
+    This is intended for classification transfer learning, where a 1000-class
+    ImageNet checkpoint must initialize a model with a different classifier head.
+    The normal ``pretrained=`` path remains strict so alignment tests still catch
+    incomplete or mismatched converted checkpoints.
+    """
+    state = paddle.load(checkpoint_path)
+    current_state = model.state_dict()
+    matched = {}
+    skipped_missing = []
+    skipped_shape = []
+    for name, value in state.items():
+        if name not in current_state:
+            skipped_missing.append(name)
+        elif list(value.shape) != list(current_state[name].shape):
+            skipped_shape.append({
+                "name":
+                name,
+                "checkpoint_shape":
+                list(value.shape),
+                "model_shape":
+                list(current_state[name].shape),
+            })
+        else:
+            matched[name] = value
+    current_state.update(matched)
+    model.set_state_dict(current_state)
+    return {
+        "matched_tensors": len(matched),
+        "checkpoint_tensors": len(state),
+        "skipped_missing": skipped_missing,
+        "skipped_shape": skipped_shape,
+    }
+
+
+def build_mambavision_backbone(model_name="mamba_vision_T",
+                               pretrained=None,
+                               **kwargs):
+    if model_name not in MODEL_CONFIGS:
+        raise ValueError(f"Unknown MambaVision variant: {model_name}")
+    cfg = MODEL_CONFIGS[model_name].copy()
+    cfg.update(kwargs)
+    model = MambaVisionBackbone(**cfg)
+    if pretrained:
+        state = paddle.load(pretrained)
+        current_state = model.state_dict()
+        current_state.update({
+            k: v
+            for k, v in state.items() if k in current_state
+        })
+        model.set_state_dict(current_state)
+    return model
+
+
+def mamba_vision_T(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_T", pretrained=pretrained, **kwargs)
+
+
+def mamba_vision_T2(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_T2",
+                             pretrained=pretrained,
+                             **kwargs)
+
+
+def mamba_vision_S(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_S", pretrained=pretrained, **kwargs)
+
+
+def mamba_vision_B(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_B", pretrained=pretrained, **kwargs)
+
+
+def mamba_vision_B_21k(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_B_21k",
+                             pretrained=pretrained,
+                             **kwargs)
+
+
+def mamba_vision_L(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_L", pretrained=pretrained, **kwargs)
+
+
+def mamba_vision_L_21k(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_L_21k",
+                             pretrained=pretrained,
+                             **kwargs)
+
+
+def mamba_vision_L2(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_L2",
+                             pretrained=pretrained,
+                             **kwargs)
+
+
+def mamba_vision_L2_512_21k(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_L2_512_21k",
+                             pretrained=pretrained,
+                             **kwargs)
+
+
+def mamba_vision_L3_256_21k(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_L3_256_21k",
+                             pretrained=pretrained,
+                             **kwargs)
+
+
+def mamba_vision_L3_512_21k(pretrained=None, **kwargs):
+    return build_mambavision("mamba_vision_L3_512_21k",
+                             pretrained=pretrained,
+                             **kwargs)

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_B.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_B.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_B
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 12
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 224
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 12
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 224
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_B_21K.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_B_21K.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_B_21K
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 8
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 224
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 8
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 224
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_L.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_L.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_L
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 6
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 224
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 6
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 224
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_L2.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_L2.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_L2
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 5
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 224
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 5
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 224
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_L2_512_21K.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_L2_512_21K.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 512, 512]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_L2_512_21K
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 512
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 1
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 551
+        - CropImage:
+            size: 512
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 1
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 551
+    - CropImage:
+        size: 512
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_L3_256_21K.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_L3_256_21K.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 256, 256]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_L3_256_21K
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 256
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 1
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 256
+        - CropImage:
+            size: 256
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 1
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 256
+    - CropImage:
+        size: 256
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_L3_512_21K.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_L3_512_21K.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 512, 512]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_L3_512_21K
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 512
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 1
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 551
+        - CropImage:
+            size: 512
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 1
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 551
+    - CropImage:
+        size: 512
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_L_21K.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_L_21K.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_L_21K
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 3
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 224
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 3
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 224
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_S.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_S.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_S
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 20
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 241
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 20
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 241
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_T
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 32
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 224
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 32
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 224
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/ppcls/configs/ImageNet/MambaVision/MambaVision_T2.yaml
+++ b/ppcls/configs/ImageNet/MambaVision/MambaVision_T2.yaml
@@ -1,0 +1,120 @@
+Global:
+  checkpoints: null
+  pretrained_model: null
+  output_dir: ./output/
+  device: gpu
+  save_interval: 1
+  eval_during_train: false
+  epochs: 300
+  print_batch_step: 10
+  use_visualdl: false
+  image_shape: [3, 224, 224]
+  to_static: false
+  seed: 2026
+
+AMP:
+  use_amp: false
+  use_fp16_test: false
+  scale_loss: 1.0
+  use_dynamic_loss_scaling: true
+  level: O1
+
+Arch:
+  name: MambaVision_T2
+  class_num: 1000
+  scan_impl: parallel
+
+Loss:
+  Train:
+    - CELoss:
+        weight: 1.0
+
+Optimizer:
+  name: AdamW
+  lr:
+    name: Constant
+    learning_rate: 1.0e-4
+  weight_decay: 0.01
+  one_dim_param_no_weight_decay: true
+
+DataLoader:
+  Train:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/train_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - RandCropImage:
+            size: 224
+        - RandFlipImage:
+            flip_code: 1
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 24
+      drop_last: false
+      shuffle: true
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+  Eval:
+    dataset:
+      name: ImageNetDataset
+      image_root: ./dataset/ILSVRC2012/
+      cls_label_path: ./dataset/ILSVRC2012/val_list.txt
+      transform_ops:
+        - DecodeImage:
+            to_rgb: true
+            channel_first: false
+        - ResizeImage:
+            resize_short: 229
+        - CropImage:
+            size: 224
+        - NormalizeImage:
+            scale: 1.0/255.0
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+            order: ''
+    sampler:
+      name: DistributedBatchSampler
+      batch_size: 24
+      drop_last: false
+      shuffle: false
+    loader:
+      num_workers: 4
+      use_shared_memory: false
+
+Infer:
+  infer_imgs: docs/images/inference_deployment/whl_demo.jpg
+  batch_size: 1
+  transforms:
+    - DecodeImage:
+        to_rgb: true
+        channel_first: false
+    - ResizeImage:
+        resize_short: 229
+    - CropImage:
+        size: 224
+    - NormalizeImage:
+        scale: 1.0/255.0
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]
+        order: ''
+    - ToCHWImage:
+  PostProcess:
+    name: Topk
+    topk: 5
+    class_id_map_file: ppcls/utils/imagenet1k_label_list.txt
+
+Metric:
+  Eval:
+    - TopkAcc:
+        topk: [1, 5]

--- a/test_tipc/configs/MambaVision/MambaVision_T_train_infer_python.txt
+++ b/test_tipc/configs/MambaVision/MambaVision_T_train_infer_python.txt
@@ -1,0 +1,62 @@
+===========================train_params===========================
+model_name:MambaVision_T
+python:python
+gpu_list:0
+-o Global.device:gpu
+-o Global.auto_cast:null
+-o Global.epochs:lite_train_lite_infer=1|whole_train_whole_infer=300
+-o Global.output_dir:./output/
+-o DataLoader.Train.sampler.batch_size:1
+-o Global.pretrained_model:null
+train_model_name:latest
+train_infer_img_dir:./dataset/ILSVRC2012/val
+-o Global.iter_per_epoch:1
+##
+trainer:norm_train|to_static_train
+norm_train:test_tipc/mambavision_train.py -c ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml -o Global.seed=2026 -o DataLoader.Train.sampler.shuffle=False -o DataLoader.Train.loader.num_workers=0 -o DataLoader.Train.loader.use_shared_memory=False -o Global.eval_during_train=False -o Global.save_interval=1
+pact_train:null
+fpgm_train:null
+distill_train:null
+to_static_train:-o Global.to_static=True
+null:null
+##
+===========================eval_params===========================
+eval:null
+null:null
+##
+===========================infer_params==========================
+-o Global.save_inference_dir:./inference
+-o Global.pretrained_model:
+norm_export:tools/export_model.py -c ppcls/configs/ImageNet/MambaVision/MambaVision_T.yaml
+quant_export:null
+fpgm_export:null
+distill_export:null
+kl_quant:null
+export2:null
+pretrained_model_url:null
+infer_model:../inference/
+infer_export:True
+infer_quant:False
+inference:../test_tipc/mambavision_predict.py -c configs/inference_cls.yaml
+-o Global.use_gpu:False
+-o Global.enable_mkldnn:False
+-o Global.cpu_num_threads:1
+-o Global.batch_size:1
+-o Global.use_tensorrt:False
+-o Global.use_fp16:False
+-o Global.inference_model_dir:../inference
+-o Global.infer_imgs:../dataset/ILSVRC2012/val/n01440764/ILSVRC2012_val_00000293.JPEG
+-o Global.save_log_path:null
+-o Global.benchmark:False
+-o Global.ir_optim:False
+null:null
+===========================train_benchmark_params==========================
+batch_size:32
+fp_items:fp32
+epoch:1
+model_type:norm_train|to_static_train
+num_workers:4
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.90
+===========================infer_benchmark_params==========================
+random_infer_input:[{float32,[3,224,224]}]

--- a/test_tipc/mambavision_predict.py
+++ b/test_tipc/mambavision_predict.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Run PaddleClas deployment with Paddle 2.6 legacy-model compatibility."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import runpy
+
+from paddle.inference import Config as PaddleInferenceConfig
+import paddleclas.deploy.utils.predictor as predictor_module
+
+
+class LegacyAwareConfig:
+    """Select the file-based constructor for legacy pdmodel exports."""
+
+    Precision = PaddleInferenceConfig.Precision
+
+    def __new__(cls, model_dir, model_prefix):
+        model_file = os.path.join(model_dir, f"{model_prefix}.pdmodel")
+        params_file = os.path.join(model_dir, f"{model_prefix}.pdiparams")
+        if os.path.isfile(model_file) and os.path.isfile(params_file):
+            return PaddleInferenceConfig(model_file, params_file)
+        return PaddleInferenceConfig(model_dir, model_prefix)
+
+
+predictor_module.Config = LegacyAwareConfig
+repo_root = Path(__file__).resolve().parents[1]
+runpy.run_path(str(repo_root / "deploy" / "python" / "predict_cls.py"),
+               run_name="__main__")

--- a/test_tipc/mambavision_train.py
+++ b/test_tipc/mambavision_train.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Adapt PaddleClas 2.6 TIPC's model-subdirectory output convention."""
+
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+
+MODEL_NAME = "MambaVision_T"
+
+
+def main() -> None:
+    for index, argument in enumerate(sys.argv):
+        prefix = "Global.output_dir="
+        if not argument.startswith(prefix):
+            continue
+        output_dir = Path(argument[len(prefix):])
+        if output_dir.name != MODEL_NAME:
+            sys.argv[index] = prefix + str(output_dir / MODEL_NAME)
+        break
+
+    train_entry = Path(__file__).resolve().parents[1] / "tools" / "train.py"
+    if not train_entry.is_file():
+        raise SystemExit(
+            f"PaddleClas tools/train.py was not found: {train_entry}")
+    sys.argv[0] = str(train_entry)
+    runpy.run_path(str(train_entry), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 修改内容

1. [add] 新增 MambaVision PaddlePaddle 实现，支持卷积、Attention 与 Mamba Mixer 结构。
2. [add] 新增纯 Paddle `sequential` 和 `parallel` selective scan 实现，不依赖自定义 CUDA 算子。
3. [add] 新增全部 11 个 MambaVision 分类模型入口，覆盖 T、T2、S、B、L、L2 和 L3 系列。
4. [add] 新增 11 份 ImageNet-1K 训练、评估和推理配置，支持 224、256 和 512 输入尺寸。
5. [update] 在 PaddleClas backbone 中注册全部 MambaVision 模型入口。
6. [add] 新增 MambaVision 模型说明、精度结果和使用文档。
7. [add] 新增 MambaVision-T TIPC 配置，覆盖动态图、静态图训练、导出和推理流程。
8. [add] 新增 Paddle 2.6 legacy inference model 与 TIPC 输出目录兼容入口。

## 复现精度

本次复现目标为模型结构、预训练权重和前向输出对齐，不包含使用 PaddlePaddle 从头完整训练复现论文精度。

- 11 个规格均使用 NVIDIA 官方 PyTorch 权重转换得到的 PaddlePaddle 权重。
- PyTorch 与 PaddlePaddle 使用相同的 ImageNet-1K 50,000 张验证图像和预处理。
- 11 个规格的逐图 Top-1 预测一致率均为 `100%`。
- 50K 评估中的最大 logits 绝对误差均小于 `1e-4`，最差结果为 `8.440e-05`。
- 原生 PaddleClas 随机输入对齐 11/11 通过，最差 logits 绝对误差为 `1.639e-06`。

## 测试

| Models | Paddle Top1 | Paddle Top5 | Reference Top1 | Reference Top5 | Params(M) |
| --- | ---: | ---: | ---: | ---: | ---: |
| MambaVision_T | 0.82176 | 0.96172 | 0.823 | 0.962 | 31.8 |
| MambaVision_T2 | 0.82636 | 0.96272 | 0.827 | 0.963 | 35.1 |
| MambaVision_S | 0.83232 | 0.96502 | 0.833 | 0.965 | 50.1 |
| MambaVision_B | 0.84204 | 0.96848 | 0.842 | 0.969 | 97.7 |
| MambaVision_B_21K | 0.84876 | 0.97478 | 0.849 | 0.975 | 97.7 |
| MambaVision_L | 0.84954 | 0.97078 | 0.850 | 0.971 | 227.9 |
| MambaVision_L_21K | 0.86140 | 0.97968 | 0.861 | 0.979 | 227.9 |
| MambaVision_L2 | 0.85282 | 0.97160 | 0.853 | 0.972 | 241.5 |
| MambaVision_L2_512_21K | 0.87114 | 0.98256 | 0.873 | 0.984 | 241.5 |
| MambaVision_L3_256_21K | 0.87294 | 0.98318 | 0.873 | 0.983 | 739.6 |
| MambaVision_L3_512_21K | 0.87822 | 0.98452 | 0.881 | 0.986 | 739.6 |

TIPC 使用 `MambaVision_T` 完成 `lite_train_lite_infer` 模式验证：

- norm train / export / inference：3/3 通过
- to_static train / export / inference：3/3 通过
- CPU 推理输出有限，无 NaN 或 Inf

## 训练

训练环境：Python 3.9、PaddlePaddle-GPU 2.6.2、PaddleClas `release/2.6`、单卡 NVIDIA GPU。

全部 11 个规格均通过 PaddleClas 官方 `tools/train.py` 完成真实 ImageNet-1K 固定批次 50-step 可训练性验证，Loss 均下降且未出现 NaN、Inf 或 AMP overflow。该测试用于验证训练链路，不代表完整 ImageNet 训练或精度复现。

| Models | Input | Batch Size | First Loss | Last Loss |
| --- | ---: | ---: | ---: | ---: |
| MambaVision_T | 224 | 32 | 0.29934 | 0.01308 |
| MambaVision_T2 | 224 | 24 | 0.38907 | 0.01320 |
| MambaVision_S | 224 | 20 | 0.48219 | 0.02104 |
| MambaVision_B | 224 | 12 | 0.75239 | 0.01885 |
| MambaVision_B_21K | 224 | 8 | 0.73282 | 0.02289 |
| MambaVision_L | 224 | 6 | 1.69471 | 0.05545 |
| MambaVision_L_21K | 224 | 3 | 1.22610 | 0.03584 |
| MambaVision_L2 | 224 | 5 | 1.90336 | 0.05791 |
| MambaVision_L2_512_21K | 512 | 1 | 6.95820 | 6.75552 |
| MambaVision_L3_256_21K | 256 | 1 | 6.88040 | 6.61510 |
| MambaVision_L3_512_21K | 512 | 3 | 1.56504 | 0.04674 |

## 模型权重

PaddlePaddle 权重下载地址：[AI Studio MambaVision 模型空间](https://aistudio.baidu.com/modelsdetail/51615)

下载对应 `.pdparams` 文件后，通过 `Global.pretrained_model` 或模型工厂的 `pretrained` 参数传入本地路径。

## 相关链接

- Paper: [MambaVision: A Hybrid Mamba-Transformer Vision Backbone](https://arxiv.org/abs/2407.08083)
- Official repository: [NVlabs/MambaVision](https://github.com/NVlabs/MambaVision)
- Source code license: NVIDIA Source Code License-NC
- Pretrained weight license: CC-BY-NC-SA-4.0